### PR TITLE
MAT 62 - 67 Revised with Single Click event

### DIFF
--- a/src/main/java/mat/client/cql/CQLLibrarySearchView.java
+++ b/src/main/java/mat/client/cql/CQLLibrarySearchView.java
@@ -248,7 +248,7 @@ public class CQLLibrarySearchView implements HasSelectionHandlers<CQLLibraryData
 								+ "History in fourth column, Transfer Check box in fifth column");
 				table.getElement().setAttribute("id", "CQLLibrarySearchCellTable");
 				table.getElement().setAttribute("aria-describedby", "CQLLibraryTransferOwnershipSummary");
-				table.setColumnWidth(0, 50.0, Unit.PCT);
+				table.setColumnWidth(0, 6.0, Unit.PCT);
 				table.setColumnWidth(1, 15.0, Unit.PCT);
 				table.setColumnWidth(2, 15.0, Unit.PCT);
 				table.setColumnWidth(3, 5.0, Unit.PCT);
@@ -264,7 +264,7 @@ public class CQLLibrarySearchView implements HasSelectionHandlers<CQLLibraryData
 								+ "History in fourth column, Share in fifth column");
 				table.getElement().setAttribute("id", "CQLLibrarySearchCellTable");
 				table.getElement().setAttribute("aria-describedby", "CQLLibrarySearchSummary");
-				table.setColumnWidth(0, 50.0, Unit.PCT);
+				table.setColumnWidth(0, 6.0, Unit.PCT);
 				table.setColumnWidth(1, 15.0, Unit.PCT);
 				table.setColumnWidth(2, 15.0, Unit.PCT);
 				table.setColumnWidth(3, 5.0, Unit.PCT);

--- a/src/main/java/mat/client/shared/CQLLibraryResultTable.java
+++ b/src/main/java/mat/client/shared/CQLLibraryResultTable.java
@@ -1,22 +1,12 @@
 package mat.client.shared;
 
 import com.google.gwt.cell.client.CheckboxCell;
-import com.google.gwt.event.dom.client.DoubleClickEvent;
-import com.google.gwt.event.dom.client.DoubleClickHandler;
 import com.google.gwt.cell.client.*;
 import com.google.gwt.event.logical.shared.SelectionEvent;
-import com.google.gwt.view.client.SingleSelectionModel;
 import mat.shared.model.util.MeasureDetailsUtil;
-import org.gwtbootstrap3.client.ui.constants.ButtonType;
-import org.gwtbootstrap3.client.ui.gwt.ButtonCell;
-
-import com.google.gwt.cell.client.Cell.Context;
-import com.google.gwt.dom.client.BrowserEvents;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
-import com.google.gwt.dom.client.TableCaptionElement;
 import com.google.gwt.event.logical.shared.HasSelectionHandlers;
-import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
@@ -28,7 +18,6 @@ import mat.client.cql.CQLLibrarySearchView.Observer;
 import mat.client.util.CellTableUtility;
 import mat.model.cql.CQLLibraryDataSetObject;
 import mat.shared.ClickableSafeHtmlCell;
-import mat.shared.model.util.MeasureDetailsUtil;
 
 public class CQLLibraryResultTable {
 

--- a/src/main/java/mat/client/shared/CQLLibraryResultTable.java
+++ b/src/main/java/mat/client/shared/CQLLibraryResultTable.java
@@ -1,10 +1,8 @@
 package mat.client.shared;
 
 import com.google.gwt.cell.client.*;
-import com.google.gwt.event.dom.client.DoubleClickEvent;
-import com.google.gwt.event.dom.client.DoubleClickHandler;
 import com.google.gwt.event.logical.shared.SelectionEvent;
-import com.google.gwt.view.client.MultiSelectionModel;
+import com.google.gwt.view.client.SingleSelectionModel;
 import mat.shared.model.util.MeasureDetailsUtil;
 import org.gwtbootstrap3.client.ui.constants.ButtonType;
 import org.gwtbootstrap3.client.ui.gwt.ButtonCell;
@@ -30,6 +28,7 @@ import mat.shared.ClickableSafeHtmlCell;
 public class CQLLibraryResultTable {
 
 	private Observer observer;
+	long lastClick = 0;
 
 	public CellTable<CQLLibraryDataSetObject> addColumnToTable(String Label, CellTable<CQLLibraryDataSetObject> table, HasSelectionHandlers<CQLLibraryDataSetObject> fireEvent) {
 		Label cqlLibrarySearchHeader = new Label(Label);
@@ -40,14 +39,17 @@ public class CQLLibraryResultTable {
 		TableCaptionElement caption = elem.createCaption();
 		caption.appendChild(cqlLibrarySearchHeader.getElement());
 
-		MultiSelectionModel<CQLLibraryDataSetObject> selectionModel = new MultiSelectionModel<>();
+
+		//Checkboxes to select specific row
+		SingleSelectionModel<CQLLibraryDataSetObject> selectionModel = new SingleSelectionModel<>();
         table.setSelectionModel(selectionModel);
+
+		//Todo Imlemented during MAT - 63/68
 
         CheckboxCell selectedCell = new CheckboxCell(true, false);
         Column<CQLLibraryDataSetObject,Boolean> selectedCol = new Column<CQLLibraryDataSetObject, Boolean>(selectedCell){
             @Override
             public Boolean getValue(CQLLibraryDataSetObject object) {
-                //Todo Imlemented during MAT - 63/68
                 return selectionModel.isSelected(object);
             }
         };
@@ -62,40 +64,74 @@ public class CQLLibraryResultTable {
 			public SafeHtml getValue(CQLLibraryDataSetObject object) {
 				return getCQLLibraryNameColumnToolTip(object);
 			}
-		};
-//		Double Click event on Grid row to navigate to Composer Tab.
-		if(MatContext.get().getMatOnFHIR().getFlagOn()) {
-			table.addDomHandler(new DoubleClickHandler() {
-				@Override
-				public void onDoubleClick(DoubleClickEvent event) {
-					for (CQLLibraryDataSetObject object : selectionModel.getSelectedSet()) {
-						SelectionEvent.fire(fireEvent, object);
-					}
+			/*
+				Single Click to select row and enable checkbox
+				Double Click to navigate to CQL Composer tab
+			*/
+			@Override
+			public void onBrowserEvent(Cell.Context context, Element elem, CQLLibraryDataSetObject object, NativeEvent event) {
+				if (lastClick < System.currentTimeMillis() - 500)
+				{
+					object.setSelected(!object.isSelected());
+					selectionModel.setSelected(object, object.isSelected());
+				}else{
+					SelectionEvent.fire(fireEvent, object);
 				}
-			}, DoubleClickEvent.getType());
-		}
+				lastClick = System.currentTimeMillis();
+			}
+		};
 		table.addColumn(cqlLibraryName,
 				SafeHtmlUtils.fromSafeConstant("<span title='CQL Library Name'>" + "CQL Library Name" + "</span>"));
 
 		// Version Column
 		Column<CQLLibraryDataSetObject, SafeHtml> version = new Column<CQLLibraryDataSetObject, SafeHtml>(
-				new MatSafeHTMLCell()) {
+				new ClickableSafeHtmlCell()) {
 			@Override
 			public SafeHtml getValue(CQLLibraryDataSetObject object) {
 				return CellTableUtility.getColumnToolTip(object.getVersion());
+			}
+			/*
+				Single Click to select row and enable checkbox
+				Double Click to navigate to CQL Composer tab
+			*/
+			@Override
+			public void onBrowserEvent(Cell.Context context, Element elem, CQLLibraryDataSetObject object, NativeEvent event) {
+				if (lastClick < System.currentTimeMillis() - 500)
+				{
+					object.setSelected(!object.isSelected());
+					selectionModel.setSelected(object, object.isSelected());
+				}else{
+					SelectionEvent.fire(fireEvent, object);
+				}
+				lastClick = System.currentTimeMillis();
 			}
 		};
 		table.addColumn(version, SafeHtmlUtils.fromSafeConstant("<span title='Version'>" + "Version" + "</span>"));
 
 		//Library Model Type
 		Column<CQLLibraryDataSetObject, SafeHtml> model = new Column<CQLLibraryDataSetObject, SafeHtml>(
-				new MatSafeHTMLCell()) {
+				new ClickableSafeHtmlCell()) {
 			@Override
 			public SafeHtml getValue(CQLLibraryDataSetObject object) {
 				if(object.getLibraryModelType() != null && !object.getLibraryModelType().isEmpty())
 					return CellTableUtility.getColumnToolTip(object.getLibraryModelType());
 				else
 					return CellTableUtility.getColumnToolTip(MeasureDetailsUtil.PRE_CQL);
+			}
+			/*
+				Single Click to select row and enable checkbox
+				Double Click to navigate to CQL Composer tab
+			*/
+			@Override
+			public void onBrowserEvent(Cell.Context context, Element elem, CQLLibraryDataSetObject object, NativeEvent event) {
+				if (lastClick < System.currentTimeMillis() - 500)
+				{
+					object.setSelected(!object.isSelected());
+					selectionModel.setSelected(object, object.isSelected());
+				}else{
+					SelectionEvent.fire(fireEvent, object);
+				}
+				lastClick = System.currentTimeMillis();
 			}
 		};
 		if(MatContext.get().getMatOnFHIR().getFlagOn())

--- a/src/main/java/mat/client/shared/CQLLibraryResultTable.java
+++ b/src/main/java/mat/client/shared/CQLLibraryResultTable.java
@@ -28,7 +28,7 @@ import mat.shared.ClickableSafeHtmlCell;
 public class CQLLibraryResultTable {
 
 	private Observer observer;
-	long lastClick = 0;
+	private final int DELAY_TIME = 500;
 
 	public CellTable<CQLLibraryDataSetObject> addColumnToTable(String Label, CellTable<CQLLibraryDataSetObject> table, HasSelectionHandlers<CQLLibraryDataSetObject> fireEvent) {
 		Label cqlLibrarySearchHeader = new Label(Label);
@@ -68,16 +68,16 @@ public class CQLLibraryResultTable {
 				Single Click to select row and enable checkbox
 				Double Click to navigate to CQL Composer tab
 			*/
-			@Override
+            @Override
 			public void onBrowserEvent(Cell.Context context, Element elem, CQLLibraryDataSetObject object, NativeEvent event) {
-				if (lastClick < System.currentTimeMillis() - 500)
+				if (object.getLastClick() < System.currentTimeMillis() - DELAY_TIME)
 				{
 					object.setSelected(!object.isSelected());
 					selectionModel.setSelected(object, object.isSelected());
 				}else{
 					SelectionEvent.fire(fireEvent, object);
 				}
-				lastClick = System.currentTimeMillis();
+				object.setLastClick(System.currentTimeMillis());
 			}
 		};
 		table.addColumn(cqlLibraryName,
@@ -94,17 +94,17 @@ public class CQLLibraryResultTable {
 				Single Click to select row and enable checkbox
 				Double Click to navigate to CQL Composer tab
 			*/
-			@Override
-			public void onBrowserEvent(Cell.Context context, Element elem, CQLLibraryDataSetObject object, NativeEvent event) {
-				if (lastClick < System.currentTimeMillis() - 500)
-				{
-					object.setSelected(!object.isSelected());
-					selectionModel.setSelected(object, object.isSelected());
-				}else{
-					SelectionEvent.fire(fireEvent, object);
-				}
-				lastClick = System.currentTimeMillis();
-			}
+            @Override
+            public void onBrowserEvent(Cell.Context context, Element elem, CQLLibraryDataSetObject object, NativeEvent event) {
+                if (object.getLastClick() < System.currentTimeMillis() - DELAY_TIME)
+                {
+                    object.setSelected(!object.isSelected());
+                    selectionModel.setSelected(object, object.isSelected());
+                }else{
+                    SelectionEvent.fire(fireEvent, object);
+                }
+                object.setLastClick(System.currentTimeMillis());
+            }
 		};
 		table.addColumn(version, SafeHtmlUtils.fromSafeConstant("<span title='Version'>" + "Version" + "</span>"));
 
@@ -122,17 +122,17 @@ public class CQLLibraryResultTable {
 				Single Click to select row and enable checkbox
 				Double Click to navigate to CQL Composer tab
 			*/
-			@Override
-			public void onBrowserEvent(Cell.Context context, Element elem, CQLLibraryDataSetObject object, NativeEvent event) {
-				if (lastClick < System.currentTimeMillis() - 500)
-				{
-					object.setSelected(!object.isSelected());
-					selectionModel.setSelected(object, object.isSelected());
-				}else{
-					SelectionEvent.fire(fireEvent, object);
-				}
-				lastClick = System.currentTimeMillis();
-			}
+            @Override
+            public void onBrowserEvent(Cell.Context context, Element elem, CQLLibraryDataSetObject object, NativeEvent event) {
+                if (object.getLastClick() < System.currentTimeMillis() - DELAY_TIME)
+                {
+                    object.setSelected(!object.isSelected());
+                    selectionModel.setSelected(object, object.isSelected());
+                }else{
+                    SelectionEvent.fire(fireEvent, object);
+                }
+                object.setLastClick(System.currentTimeMillis());
+            }
 		};
 		if(MatContext.get().getMatOnFHIR().getFlagOn())
 			table.addColumn(model, SafeHtmlUtils.fromSafeConstant("<span title='Version'>" + "Model" + "</span>"));

--- a/src/main/java/mat/model/cql/CQLLibraryDataSetObject.java
+++ b/src/main/java/mat/model/cql/CQLLibraryDataSetObject.java
@@ -39,9 +39,18 @@ public class CQLLibraryDataSetObject implements IsSerializable,BaseModel{
 	private boolean isVersionable;
 	private boolean isDeletable;
 	private String libraryModelType;
+	private long lastClick;
 
 	/** The cql errors. */
 	private List<CQLError> cqlErrors = new ArrayList<CQLError>();
+
+	public long getLastClick() {
+		return lastClick;
+	}
+
+	public void setLastClick(long lastClick) {
+		this.lastClick = lastClick;
+	}
 	
 	public boolean isLocked() {
 		return isLocked;

--- a/src/main/java/mat/model/cql/CQLLibraryDataSetObject.java
+++ b/src/main/java/mat/model/cql/CQLLibraryDataSetObject.java
@@ -39,17 +39,6 @@ public class CQLLibraryDataSetObject implements IsSerializable,BaseModel{
 	private boolean isVersionable;
 	private boolean isDeletable;
 	private String libraryModelType;
-	private boolean isCheckboxSelected = false;
-
-
-	public boolean isCheckboxSelected() {
-		return isCheckboxSelected;
-	}
-
-	public void setCheckboxSelected(boolean checkboxSelected) {
-		isCheckboxSelected = checkboxSelected;
-	}
-
 
 	/** The cql errors. */
 	private List<CQLError> cqlErrors = new ArrayList<CQLError>();


### PR DESCRIPTION
Differentiated Single Click and Double Click using SystemTime with 500ms as ideal threshold for consecutive clicks. 

'onBrowserEvent' is performed on a column instead of a row. So it is added for LibraryName Column, Version Column and Model Type Column. Hasn't implemented on other columns since they will be removed in MAT 63 & 68.

<img width="880" alt="image" src="https://user-images.githubusercontent.com/57495404/70919334-b0f8e300-1fee-11ea-990e-b554ede8841e.png">

Note: removed the unwanted lines of code and previous implementations/ideas.