### PR TITLE
Remove the lines that skip unit tests for LGTM 

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -4,5 +4,4 @@ extraction:
       build_command:
       - "./install-deps.sh"
       - "mvn clean package -f \"pom.xml\" -B -V -e -Dfindbugs.skip -Dcheckstyle.skip\
-        \ -Dpmd.skip=true -Denforcer.skip -Dmaven.javadoc.skip -DskipTests -Dmaven.test.skip.exec\
-        \ -Dlicense.skip=true"
+        \ -Dpmd.skip=true -Denforcer.skip -Dmaven.javadoc.skip -Dlicense.skip=true"


### PR DESCRIPTION
Remove the lines that skip unit tests for LGTM so they are accounted for during a build.

There is a desire to include unit test as part of the build criteria in the SAST process when LGTM builds the code. This commit modifies the lgtm.yml to not skip unit tests. While LGTM's focus is primarily security analysis, this change allows us to include successful unit tests as part as our successful build criteria which factors into our code quality over all.

This will also mean that breaking unit tests on a PR will not build successfully in LGTM. The assumed goal is that a PR should not break unit tests in any case, and if it does, it should be fixed. That said, this is an assumed case and as such should be taken into consideration during review.

Screenshot showing successful test build with new configuration was successful:
![Screen Shot 2019-12-19 at 12 28 05 PM](https://user-images.githubusercontent.com/55987911/71195038-181acf80-225b-11ea-9037-1e977288e52f.png)
