### PR TITLE
Feature/mat 312 mvp feature flags

### DIFF
--- a/src/main/java/liquibase/addMVPFeatureFlags.xml
+++ b/src/main/java/liquibase/addMVPFeatureFlags.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet author="mat_dev_user" id="1" context="prod">
+        <sql>
+            INSERT INTO `FEATURE_FLAGS` (FLAG_NAME, FLAG_ON)
+            VALUES ('FhirConvV1', 0),
+            ('FhirEdit', 0),
+            ('FhirAdd', 0),
+            ('DraftVersion', 0),
+            ('PackageV1', 0),
+            ('ExportV1', 0),
+            ('FhirShare', 0),
+            ('FhirView', 0),
+            ('FhirDelete', 0);
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/java/liquibase/changelog.xml
+++ b/src/main/java/liquibase/changelog.xml
@@ -8,4 +8,5 @@
     <include file="classpath:/liquibase/featureFlagDataBaseChanges.xml"/>
     <include file="classpath:/liquibase/addMeasureModelColumn.xml"/>
     <include file="classpath:/liquibase/addLibraryModelColumn.xml"/>
+    <include file="classpath:/liquibase/addMVPFeatureFlags.xml"/>
 </databaseChangeLog>

--- a/src/main/java/mat/client/CqlComposerPresenter.java
+++ b/src/main/java/mat/client/CqlComposerPresenter.java
@@ -19,6 +19,7 @@ import mat.client.shared.MatContext;
 import mat.client.shared.MatTabLayoutPanel;
 import mat.client.shared.SkipListBuilder;
 import mat.client.shared.WarningConfirmationMessageAlert;
+import mat.client.util.FeatureFlagConstant;
 import mat.shared.ConstantMessages;
 import mat.shared.model.util.MeasureDetailsUtil;
 
@@ -193,7 +194,7 @@ public class CqlComposerPresenter implements MatPresenter, Enableable, TabObserv
 
     private static String getHeadingLibraryModel() {
         String model = "";
-        if (MatContext.get().getMatOnFHIR().getFlagOn()) {
+        if (MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.MAT_ON_FHIR)) {
             model = " (" + MeasureDetailsUtil.defaultTypeIfBlank(MatContext.get().getCurrentLibraryInfo().getLibraryModelType()) + ")";
         }
         return model;

--- a/src/main/java/mat/client/Mat.java
+++ b/src/main/java/mat/client/Mat.java
@@ -277,7 +277,7 @@ public class Mat extends MainLayout implements EntryPoint, Enableable, TabObserv
 	protected void initEntryPoint() {
 		MatContext.get().setCurrentModule(ConstantMessages.MAT_MODULE);
 		
-		MatContext.get().getFeatureFlagService().findFeatureFlag(new AsyncCallback<List<FeatureFlag>>() {
+		MatContext.get().getFeatureFlagService().findFeatureFlags(new AsyncCallback<List<FeatureFlag>>() {
 			@Override
 			public void onFailure(Throwable caught) {
 				Window.alert(MessageDelegate.GENERIC_ERROR_MESSAGE);

--- a/src/main/java/mat/client/Mat.java
+++ b/src/main/java/mat/client/Mat.java
@@ -3,6 +3,7 @@ package mat.client;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import com.google.gwt.core.client.EntryPoint;
 import com.google.gwt.core.client.GWT;
@@ -68,7 +69,6 @@ import mat.client.umls.ManageUmlsPresenter;
 import mat.client.umls.UmlsLoginDialogBox;
 import mat.client.umls.service.VsacTicketInformation;
 import mat.client.util.ClientConstants;
-import mat.model.FeatureFlag;
 import mat.shared.ConstantMessages;
 import mat.shared.bonnie.result.BonnieUserInformationResult;
 
@@ -277,17 +277,16 @@ public class Mat extends MainLayout implements EntryPoint, Enableable, TabObserv
 	protected void initEntryPoint() {
 		MatContext.get().setCurrentModule(ConstantMessages.MAT_MODULE);
 		
-		MatContext.get().getFeatureFlagService().findFeatureFlags(new AsyncCallback<List<FeatureFlag>>() {
+		MatContext.get().getFeatureFlagService().findFeatureFlags(new AsyncCallback<Map<String, Boolean>>() {
 			@Override
 			public void onFailure(Throwable caught) {
 				Window.alert(MessageDelegate.GENERIC_ERROR_MESSAGE);
 			}
 
 			@Override
-			public void onSuccess(List<FeatureFlag> result) {
+			public void onSuccess(Map<String, Boolean> result) {
 				MatContext.get().setFeatureFlags(result);
 			}
-			
 		});
 		
 		showLoadingMessage();

--- a/src/main/java/mat/client/Mat.java
+++ b/src/main/java/mat/client/Mat.java
@@ -277,15 +277,15 @@ public class Mat extends MainLayout implements EntryPoint, Enableable, TabObserv
 	protected void initEntryPoint() {
 		MatContext.get().setCurrentModule(ConstantMessages.MAT_MODULE);
 		
-		MatContext.get().getFeatureFlagService().findFeatureFlag("MAT_ON_FHIR", new AsyncCallback<FeatureFlag>() {
+		MatContext.get().getFeatureFlagService().findFeatureFlag(new AsyncCallback<List<FeatureFlag>>() {
 			@Override
 			public void onFailure(Throwable caught) {
 				Window.alert(MessageDelegate.GENERIC_ERROR_MESSAGE);
 			}
-			
+
 			@Override
-			public void onSuccess(FeatureFlag result) {
-				MatContext.get().setMatOnFHIR(result);
+			public void onSuccess(List<FeatureFlag> result) {
+				MatContext.get().setFeatureFlags(result);
 			}
 			
 		});

--- a/src/main/java/mat/client/MeasureComposerPresenter.java
+++ b/src/main/java/mat/client/MeasureComposerPresenter.java
@@ -3,6 +3,7 @@ package mat.client;
 import java.util.LinkedList;
 import java.util.List;
 
+import mat.client.util.FeatureFlagConstant;
 import org.gwtbootstrap3.client.ui.Button;
 
 import com.google.gwt.core.client.Scheduler;
@@ -284,7 +285,7 @@ public class MeasureComposerPresenter implements MatPresenter, MeasureHeading, E
 
     private static String getHeadingMeasureModel() {
         String model = "";
-        if (MatContext.get().getMatOnFHIR().getFlagOn()) {
+        if (MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.MAT_ON_FHIR)) {
             model = " (" + MeasureDetailsUtil.defaultTypeIfBlank(MatContext.get().getCurrentMeasureInfo().getMeasureModel()) + ")";
         }
         return model;

--- a/src/main/java/mat/client/cql/NewLibraryView.java
+++ b/src/main/java/mat/client/cql/NewLibraryView.java
@@ -1,5 +1,6 @@
 package mat.client.cql;
 
+import mat.client.util.FeatureFlagConstant;
 import org.gwtbootstrap3.client.ui.FieldSet;
 import org.gwtbootstrap3.client.ui.Form;
 import org.gwtbootstrap3.client.ui.FormGroup;
@@ -143,7 +144,7 @@ public class NewLibraryView implements CqlLibraryPresenter.DetailDisplay {
      * Add measure model type radios to create measure view iff 'MAT_ON_FHIR' flag is on
      */
     private void addLibraryModelType() {
-        if (MatContext.get().getMatOnFHIR().getFlagOn()) {
+        if (MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.MAT_ON_FHIR)) {
             VerticalPanel modelTypePanel = buildModelTypePanel();
             libraryModelGroup.add(modelTypePanel);
         }

--- a/src/main/java/mat/client/featureFlag/service/FeatureFlagService.java
+++ b/src/main/java/mat/client/featureFlag/service/FeatureFlagService.java
@@ -5,9 +5,10 @@ import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 
 import mat.model.FeatureFlag;
 
+import java.util.List;
+
 @RemoteServiceRelativePath("featureFlag")
 public interface FeatureFlagService extends RemoteService {
 
-	
-	FeatureFlag findFeatureFlag(String flagName);
+	List<FeatureFlag> findFeatureFlag();
 }

--- a/src/main/java/mat/client/featureFlag/service/FeatureFlagService.java
+++ b/src/main/java/mat/client/featureFlag/service/FeatureFlagService.java
@@ -10,5 +10,5 @@ import java.util.List;
 @RemoteServiceRelativePath("featureFlag")
 public interface FeatureFlagService extends RemoteService {
 
-	List<FeatureFlag> findFeatureFlag();
+	List<FeatureFlag> findFeatureFlags();
 }

--- a/src/main/java/mat/client/featureFlag/service/FeatureFlagService.java
+++ b/src/main/java/mat/client/featureFlag/service/FeatureFlagService.java
@@ -3,12 +3,10 @@ package mat.client.featureFlag.service;
 import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 
-import mat.model.FeatureFlag;
-
-import java.util.List;
+import java.util.Map;
 
 @RemoteServiceRelativePath("featureFlag")
 public interface FeatureFlagService extends RemoteService {
 
-	List<FeatureFlag> findFeatureFlags();
+	Map<String, Boolean> findFeatureFlags();
 }

--- a/src/main/java/mat/client/featureFlag/service/FeatureFlagServiceAsync.java
+++ b/src/main/java/mat/client/featureFlag/service/FeatureFlagServiceAsync.java
@@ -9,5 +9,5 @@ import java.util.List;
 
 public interface FeatureFlagServiceAsync extends AsynchronousService{
 
-	void findFeatureFlag(AsyncCallback<List<FeatureFlag>> callback);
+	void findFeatureFlags(AsyncCallback<List<FeatureFlag>> callback);
 }

--- a/src/main/java/mat/client/featureFlag/service/FeatureFlagServiceAsync.java
+++ b/src/main/java/mat/client/featureFlag/service/FeatureFlagServiceAsync.java
@@ -3,11 +3,9 @@ package mat.client.featureFlag.service;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 
 import mat.client.login.service.AsynchronousService;
-import mat.model.FeatureFlag;
-
-import java.util.List;
+import java.util.Map;
 
 public interface FeatureFlagServiceAsync extends AsynchronousService{
 
-	void findFeatureFlags(AsyncCallback<List<FeatureFlag>> callback);
+	void findFeatureFlags(AsyncCallback<Map<String, Boolean>> callback);
 }

--- a/src/main/java/mat/client/featureFlag/service/FeatureFlagServiceAsync.java
+++ b/src/main/java/mat/client/featureFlag/service/FeatureFlagServiceAsync.java
@@ -5,8 +5,9 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import mat.client.login.service.AsynchronousService;
 import mat.model.FeatureFlag;
 
+import java.util.List;
+
 public interface FeatureFlagServiceAsync extends AsynchronousService{
 
-	
-	void findFeatureFlag(String flagName, AsyncCallback<FeatureFlag> callback);
+	void findFeatureFlag(AsyncCallback<List<FeatureFlag>> callback);
 }

--- a/src/main/java/mat/client/measure/AbstractNewMeasureView.java
+++ b/src/main/java/mat/client/measure/AbstractNewMeasureView.java
@@ -3,6 +3,7 @@ package mat.client.measure;
 import java.util.List;
 
 import com.google.gwt.user.client.ui.*;
+import mat.client.util.FeatureFlagConstant;
 import mat.shared.model.util.MeasureDetailsUtil;
 import org.gwtbootstrap3.client.ui.FieldSet;
 import org.gwtbootstrap3.client.ui.FormGroup;
@@ -266,7 +267,7 @@ public class AbstractNewMeasureView implements DetailDisplay {
 	 * Add measure model type radios to create measure view iff 'MAT_ON_FHIR' flag is on
 	 */
 	protected void addMeasureModelType() {
-		if(MatContext.get().getMatOnFHIR().getFlagOn()) {
+		if(MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.MAT_ON_FHIR)) {
 			VerticalPanel modelTypePanel = buildModelTypePanel();
 			measureModelGroup.add(modelTypePanel);
 		}

--- a/src/main/java/mat/client/measure/ManageMeasurePresenter.java
+++ b/src/main/java/mat/client/measure/ManageMeasurePresenter.java
@@ -3,6 +3,7 @@ package mat.client.measure;
 import java.util.ArrayList;
 import java.util.List;
 
+import mat.client.util.FeatureFlagConstant;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.constants.ButtonDismiss;
 import org.gwtbootstrap3.client.ui.constants.ButtonType;
@@ -867,7 +868,7 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
         searchDisplay.getCellTablePanel().clear();
         String heading = "Measure Library";
 
-        if (MatContext.get().getMatOnFHIR().getFlagOn()) {
+        if (MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.MAT_ON_FHIR)) {
             heading = "MAT on FHIR - Measure Library";
         } else {
             heading = "MAT on QDM - Measure Library";

--- a/src/main/java/mat/client/shared/CQLLibraryResultTable.java
+++ b/src/main/java/mat/client/shared/CQLLibraryResultTable.java
@@ -3,6 +3,7 @@ package mat.client.shared;
 import com.google.gwt.cell.client.CheckboxCell;
 import com.google.gwt.cell.client.*;
 import com.google.gwt.event.logical.shared.SelectionEvent;
+import mat.client.util.FeatureFlagConstant;
 import mat.shared.model.util.MeasureDetailsUtil;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
@@ -122,7 +123,7 @@ public class CQLLibraryResultTable {
                 object.setLastClick(System.currentTimeMillis());
             }
         };
-        if (MatContext.get().getMatOnFHIR().getFlagOn())
+        if (MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.MAT_ON_FHIR))
             table.addColumn(model, SafeHtmlUtils.fromSafeConstant("<span title='Version'>" + "Model" + "</span>"));
 
         table.addStyleName("table");
@@ -189,7 +190,7 @@ public class CQLLibraryResultTable {
     private SafeHtml getCQLLibraryNameColumnToolTip(CQLLibraryDataSetObject object) {
         SafeHtmlBuilder sb = new SafeHtmlBuilder();
         String cssClass = "customCascadeButton";
-        String editState = MatContext.get().getMatOnFHIR().getFlagOn() ? getEditStateOfLibrary(object) : "";
+        String editState = MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.MAT_ON_FHIR) ? getEditStateOfLibrary(object) : "";
         if (object.isFamily()) {
             sb.appendHtmlConstant("<div tabindex=\"-1\">");
             sb.appendHtmlConstant(editState);

--- a/src/main/java/mat/client/shared/MatContext.java
+++ b/src/main/java/mat/client/shared/MatContext.java
@@ -74,7 +74,6 @@ import mat.client.umls.service.VSACAPIService;
 import mat.client.umls.service.VSACAPIServiceAsync;
 import mat.client.umls.service.VsacApiResult;
 import mat.client.util.ClientConstants;
-import mat.model.FeatureFlag;
 import mat.model.GlobalCopyPasteObject;
 import mat.model.MeasureType;
 import mat.model.cql.CQLModel;
@@ -233,7 +232,7 @@ public class MatContext implements IsSerializable {
 
     private Map<String, String> expressionToReturnTypeMap = new HashMap<>();
 
-	private List<FeatureFlag> featureFlagList;
+	private Map<String, Boolean> featureFlagMap;
 
 	public void clearDVIMessages() {
         if (qdsView != null) {
@@ -1522,17 +1521,13 @@ public class MatContext implements IsSerializable {
         });
     }
 
-	public void setFeatureFlags(List<FeatureFlag> featureFlagList){
-		this.featureFlagList = featureFlagList;
+	public void setFeatureFlags(Map<String, Boolean> featureFlagMap){
+		this.featureFlagMap = featureFlagMap;
 	}
 
 	//returns if specific feature flag is on/off
 	public boolean getFeatureFlagStatus(String flag){
-		FeatureFlag featureFlag = this.featureFlagList.stream()
-				.filter(f -> flag.equals(f.getFlagName()))
-				.findAny()
-				.orElse(null);
-		return featureFlag.getFlagOn();
+		return featureFlagMap.get(flag);
 	}
 
     public List<MeasureType> getMeasureTypeList() {

--- a/src/main/java/mat/client/shared/MatContext.java
+++ b/src/main/java/mat/client/shared/MatContext.java
@@ -1527,7 +1527,7 @@ public class MatContext implements IsSerializable {
 
 	//returns if specific feature flag is on/off
 	public boolean getFeatureFlagStatus(String flag){
-		return featureFlagMap.get(flag);
+		return featureFlagMap.getOrDefault(flag,false);
 	}
 
     public List<MeasureType> getMeasureTypeList() {

--- a/src/main/java/mat/client/shared/MatContext.java
+++ b/src/main/java/mat/client/shared/MatContext.java
@@ -233,9 +233,9 @@ public class MatContext implements IsSerializable {
 
     private Map<String, String> expressionToReturnTypeMap = new HashMap<>();
 
-    private FeatureFlag matOnFHIR;
+	private List<FeatureFlag> featureFlagList;
 
-    public void clearDVIMessages() {
+	public void clearDVIMessages() {
         if (qdsView != null) {
             qdsView.getSuccessMessageDisplay().clear();
             qdsView.getErrorMessageDisplay().clear();
@@ -1522,13 +1522,18 @@ public class MatContext implements IsSerializable {
         });
     }
 
-    public void setMatOnFHIR(FeatureFlag matOnFHIR) {
-        this.matOnFHIR = matOnFHIR;
-    }
+	public void setFeatureFlags(List<FeatureFlag> featureFlagList){
+		this.featureFlagList = featureFlagList;
+	}
 
-    public FeatureFlag getMatOnFHIR() {
-        return this.matOnFHIR;
-    }
+	//returns if specific feature flag is on/off
+	public boolean getFeatureFlagStatus(String flag){
+		FeatureFlag featureFlag = this.featureFlagList.stream()
+				.filter(f -> flag.equals(f.getFlagName()))
+				.findAny()
+				.orElse(null);
+		return featureFlag.getFlagOn();
+	}
 
     public List<MeasureType> getMeasureTypeList() {
         return measureTypeList;

--- a/src/main/java/mat/client/shared/MeasureLibraryResultTable.java
+++ b/src/main/java/mat/client/shared/MeasureLibraryResultTable.java
@@ -9,6 +9,7 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.*;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.view.client.DefaultSelectionEventManager;
+import mat.client.util.FeatureFlagConstant;
 import mat.shared.model.util.MeasureDetailsUtil;
 import org.gwtbootstrap3.client.ui.constants.ButtonType;
 import org.gwtbootstrap3.client.ui.gwt.ButtonCell;
@@ -96,7 +97,7 @@ public class MeasureLibraryResultTable {
 				return CellTableUtility.getColumnToolTip(MeasureDetailsUtil.defaultTypeIfBlank(object.getMeasureModel()));
 			};
 		};
-		if(MatContext.get().getMatOnFHIR().getFlagOn()) {
+		if(MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.MAT_ON_FHIR)) {
 			table.addColumn(model, SafeHtmlUtils.fromSafeConstant("<span title='Model'>" + "Model" + "</span>"));
 			table.setColumnWidth(model, MODEL_COLUMN_WIDTH, Style.Unit.PCT);
 		} else {
@@ -286,7 +287,7 @@ public class MeasureLibraryResultTable {
 	private SafeHtml getMeasureNameColumnToolTip(ManageMeasureSearchModel.Result object){
 		SafeHtmlBuilder sb = new SafeHtmlBuilder();
 		String cssClass = "customCascadeButton";
-		String editState = MatContext.get().getMatOnFHIR().getFlagOn() ? getEditStateOfMeasure(object) : "";
+		String editState = MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.MAT_ON_FHIR) ? getEditStateOfMeasure(object) : "";
 		if (object.isMeasureFamily()) {
 			sb.appendHtmlConstant("<div class=\"pull-left\">")
 					.appendHtmlConstant(editState)

--- a/src/main/java/mat/client/util/FeatureFlagConstant.java
+++ b/src/main/java/mat/client/util/FeatureFlagConstant.java
@@ -1,0 +1,15 @@
+package mat.client.util;
+
+public class FeatureFlagConstant {
+
+    public final static String MAT_ON_FHIR ="MAT_ON_FHIR";
+    public final static String FHIR_CONV_V1 ="FhirConvV1";
+    public final static String FHIR_EDIT ="FhirEdit";
+    public final static String FHIR_ADD ="FhirAdd";
+    public final static String DRAFT_VERSION ="DraftVersion";
+    public final static String PACKAGE_V1 ="PackageV1";
+    public final static String EXPORT_V1 ="ExportV1";
+    public final static String FHIR_SHARE ="FhirShare";
+    public final static String FHIR_VIEW ="FhirView";
+    public final static String FHIR_DELETE ="FhirDelete";
+}

--- a/src/main/java/mat/client/util/FeatureFlagConstant.java
+++ b/src/main/java/mat/client/util/FeatureFlagConstant.java
@@ -1,15 +1,15 @@
 package mat.client.util;
 
-public class FeatureFlagConstant {
+public interface FeatureFlagConstant {
 
-    public final static String MAT_ON_FHIR ="MAT_ON_FHIR";
-    public final static String FHIR_CONV_V1 ="FhirConvV1";
-    public final static String FHIR_EDIT ="FhirEdit";
-    public final static String FHIR_ADD ="FhirAdd";
-    public final static String DRAFT_VERSION ="DraftVersion";
-    public final static String PACKAGE_V1 ="PackageV1";
-    public final static String EXPORT_V1 ="ExportV1";
-    public final static String FHIR_SHARE ="FhirShare";
-    public final static String FHIR_VIEW ="FhirView";
-    public final static String FHIR_DELETE ="FhirDelete";
+    String MAT_ON_FHIR ="MAT_ON_FHIR";
+    String FHIR_CONV_V1 ="FhirConvV1";
+    String FHIR_EDIT ="FhirEdit";
+    String FHIR_ADD ="FhirAdd";
+    String DRAFT_VERSION ="DraftVersion";
+    String PACKAGE_V1 ="PackageV1";
+    String EXPORT_V1 ="ExportV1";
+    String FHIR_SHARE ="FhirShare";
+    String FHIR_VIEW ="FhirView";
+    String FHIR_DELETE ="FhirDelete";
 }

--- a/src/main/java/mat/dao/FeatureFlagDAO.java
+++ b/src/main/java/mat/dao/FeatureFlagDAO.java
@@ -2,6 +2,8 @@ package mat.dao;
 
 import mat.model.FeatureFlag;
 
+import java.util.List;
+
 public interface FeatureFlagDAO extends IDAO<FeatureFlag, String>  {
-    public FeatureFlag findFlagByName(String flagName);
+    List<FeatureFlag> findAllFeatureFlags();
 }

--- a/src/main/java/mat/dao/impl/FeatureFlagDAOImpl.java
+++ b/src/main/java/mat/dao/impl/FeatureFlagDAOImpl.java
@@ -4,14 +4,10 @@ import mat.dao.FeatureFlagDAO;
 import mat.dao.search.GenericDAO;
 import mat.model.FeatureFlag;
 import org.apache.commons.collections.CollectionUtils;
-import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
 import java.util.List;
 
 @Repository("FeatureFlagDAO")
@@ -24,16 +20,8 @@ public class FeatureFlagDAOImpl extends GenericDAO<FeatureFlag, String> implemen
     }
 
     @Override
-    public FeatureFlag findFlagByName(String flagName) {
-        final Session session = getSessionFactory().getCurrentSession();
-        final CriteriaBuilder cb = session.getCriteriaBuilder();
-        final CriteriaQuery<FeatureFlag> query = cb.createQuery(FeatureFlag.class);
-        final Root<FeatureFlag> root = query.from(FeatureFlag.class);
-
-        query.select(root).where(cb.equal(root.get(FLAG_NAME), flagName));
-
-        final List<FeatureFlag> dataTypeList = session.createQuery(query).getResultList();
-
-        return CollectionUtils.isNotEmpty(dataTypeList) ? dataTypeList.get(0) : null;
+    public List<FeatureFlag> findAllFeatureFlags() {
+        final List<FeatureFlag> dataTypeList = find();
+        return CollectionUtils.isNotEmpty(dataTypeList) ? dataTypeList : null;
     }
 }

--- a/src/main/java/mat/dao/impl/FeatureFlagDAOImpl.java
+++ b/src/main/java/mat/dao/impl/FeatureFlagDAOImpl.java
@@ -8,6 +8,7 @@ import org.hibernate.SessionFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collections;
 import java.util.List;
 
 @Repository("FeatureFlagDAO")
@@ -22,6 +23,6 @@ public class FeatureFlagDAOImpl extends GenericDAO<FeatureFlag, String> implemen
     @Override
     public List<FeatureFlag> findAllFeatureFlags() {
         final List<FeatureFlag> dataTypeList = find();
-        return CollectionUtils.isNotEmpty(dataTypeList) ? dataTypeList : null;
+        return CollectionUtils.isNotEmpty(dataTypeList) ? dataTypeList : Collections.EMPTY_LIST;
     }
 }

--- a/src/main/java/mat/server/FeatureFlagServiceImpl.java
+++ b/src/main/java/mat/server/FeatureFlagServiceImpl.java
@@ -8,6 +8,8 @@ import mat.client.featureFlag.service.FeatureFlagService;
 import mat.dao.FeatureFlagDAO;
 import mat.model.FeatureFlag;
 
+import java.util.List;
+
 @Service
 public class FeatureFlagServiceImpl extends SpringRemoteServiceServlet implements FeatureFlagService {
 
@@ -15,10 +17,10 @@ public class FeatureFlagServiceImpl extends SpringRemoteServiceServlet implement
 
 	@Autowired
 	FeatureFlagDAO featureFlagDAO;
-	
+
 	@Override
-	public FeatureFlag findFeatureFlag(String flagName) {
-		return featureFlagDAO.findFlagByName(flagName);
+	public List<FeatureFlag> findFeatureFlag() {
+		return featureFlagDAO.findAllFeatureFlags();
 	}
 
 }

--- a/src/main/java/mat/server/FeatureFlagServiceImpl.java
+++ b/src/main/java/mat/server/FeatureFlagServiceImpl.java
@@ -8,19 +8,27 @@ import mat.client.featureFlag.service.FeatureFlagService;
 import mat.dao.FeatureFlagDAO;
 import mat.model.FeatureFlag;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class FeatureFlagServiceImpl extends SpringRemoteServiceServlet implements FeatureFlagService {
 
 	private static final long serialVersionUID = 1L;
 
+	Map<String, Boolean> featureFlagMap = new HashMap<>();
+
 	@Autowired
 	FeatureFlagDAO featureFlagDAO;
 
 	@Override
-	public List<FeatureFlag> findFeatureFlags() {
-		return featureFlagDAO.findAllFeatureFlags();
+	public Map<String, Boolean> findFeatureFlags() {
+		List<FeatureFlag> featureFlagList = featureFlagDAO.findAllFeatureFlags();
+		featureFlagMap  = featureFlagList.stream()
+				.collect(Collectors.toMap(f -> f.getFlagName(), v -> v.getFlagOn()));
+		return featureFlagMap;
 	}
 
 }

--- a/src/main/java/mat/server/FeatureFlagServiceImpl.java
+++ b/src/main/java/mat/server/FeatureFlagServiceImpl.java
@@ -19,7 +19,7 @@ public class FeatureFlagServiceImpl extends SpringRemoteServiceServlet implement
 	FeatureFlagDAO featureFlagDAO;
 
 	@Override
-	public List<FeatureFlag> findFeatureFlag() {
+	public List<FeatureFlag> findFeatureFlags() {
 		return featureFlagDAO.findAllFeatureFlags();
 	}
 

--- a/src/test/java/mat/client/CqlComposerPresenterTest.java
+++ b/src/test/java/mat/client/CqlComposerPresenterTest.java
@@ -16,18 +16,22 @@ import mat.client.shared.ContentWithHeadingWidget;
 import mat.client.shared.MatContext;
 import mat.model.FeatureFlag;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @RunWith(GwtMockitoTestRunner.class)
 public class CqlComposerPresenterTest {
 
-    private FeatureFlag featureFlag;
+    private List<FeatureFlag> featureFlaglist = new ArrayList<>();
     private ContentWithHeadingWidget cqlComposerContent;
     @Mock
     private HTML heading;
 
     @Before
     public void setup() {
-        featureFlag = new FeatureFlag();
-        MatContext.get().setMatOnFHIR(featureFlag);
+        featureFlaglist.add(new FeatureFlag(1, "MAT_ON_FHIR", false));
+        MatContext.get().setFeatureFlags(featureFlaglist);
+
         cqlComposerContent = Whitebox.getInternalState(CqlComposerPresenter.class, "cqlComposerContent");
         Assert.assertNotNull(cqlComposerContent);
         Whitebox.setInternalState(cqlComposerContent, "heading", heading);
@@ -35,7 +39,8 @@ public class CqlComposerPresenterTest {
 
     @Test
     public void testHeadingFlagOn() {
-        featureFlag.setFlagOn(true);
+        featureFlaglist.get(0).setFlagOn(true);
+
         CQLLibrarySelectedEvent selectedEvent = CQLLibrarySelectedEvent.Builder.newBuilder()
                 .withLibraryName("library1")
                 .withCqlLibraryVersion("v1")
@@ -49,7 +54,8 @@ public class CqlComposerPresenterTest {
 
     @Test
     public void testHeadingFlagOff() {
-        featureFlag.setFlagOn(false);
+        featureFlaglist.get(0).setFlagOn(false);
+
         CQLLibrarySelectedEvent selectedEvent = CQLLibrarySelectedEvent.Builder.newBuilder()
                 .withLibraryName("library1")
                 .withCqlLibraryVersion("v1")

--- a/src/test/java/mat/client/CqlComposerPresenterTest.java
+++ b/src/test/java/mat/client/CqlComposerPresenterTest.java
@@ -14,24 +14,19 @@ import com.google.gwtmockito.GwtMockitoTestRunner;
 import mat.client.event.CQLLibrarySelectedEvent;
 import mat.client.shared.ContentWithHeadingWidget;
 import mat.client.shared.MatContext;
-import mat.model.FeatureFlag;
-
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class CqlComposerPresenterTest {
 
-    private List<FeatureFlag> featureFlaglist = new ArrayList<>();
+    private Map<String, Boolean> featureFlagMap = new HashMap<>();
     private ContentWithHeadingWidget cqlComposerContent;
     @Mock
     private HTML heading;
 
     @Before
     public void setup() {
-        featureFlaglist.add(new FeatureFlag(1, "MAT_ON_FHIR", false));
-        MatContext.get().setFeatureFlags(featureFlaglist);
-
         cqlComposerContent = Whitebox.getInternalState(CqlComposerPresenter.class, "cqlComposerContent");
         Assert.assertNotNull(cqlComposerContent);
         Whitebox.setInternalState(cqlComposerContent, "heading", heading);
@@ -39,7 +34,8 @@ public class CqlComposerPresenterTest {
 
     @Test
     public void testHeadingFlagOn() {
-        featureFlaglist.get(0).setFlagOn(true);
+        featureFlagMap.put("MAT_ON_FHIR",true);
+        MatContext.get().setFeatureFlags(featureFlagMap);
 
         CQLLibrarySelectedEvent selectedEvent = CQLLibrarySelectedEvent.Builder.newBuilder()
                 .withLibraryName("library1")
@@ -54,7 +50,8 @@ public class CqlComposerPresenterTest {
 
     @Test
     public void testHeadingFlagOff() {
-        featureFlaglist.get(0).setFlagOn(false);
+        featureFlagMap.put("MAT_ON_FHIR",false);
+        MatContext.get().setFeatureFlags(featureFlagMap);
 
         CQLLibrarySelectedEvent selectedEvent = CQLLibrarySelectedEvent.Builder.newBuilder()
                 .withLibraryName("library1")

--- a/src/test/java/mat/client/MeasureComposerPresenterTest.java
+++ b/src/test/java/mat/client/MeasureComposerPresenterTest.java
@@ -10,20 +10,23 @@ import mat.client.event.MeasureSelectedEvent;
 import mat.client.shared.MatContext;
 import mat.model.FeatureFlag;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @RunWith(GwtMockitoTestRunner.class)
 public class MeasureComposerPresenterTest {
 
-    private FeatureFlag featureFlag;
+    private List<FeatureFlag> featureFlaglist = new ArrayList<>();
 
     @Before
     public void setup() {
-        featureFlag = new FeatureFlag();
-        MatContext.get().setMatOnFHIR(featureFlag);
+        featureFlaglist.add(new FeatureFlag(1, "MAT_ON_FHIR", false));
+        MatContext.get().setFeatureFlags(featureFlaglist);
     }
 
     @Test
     public void testHeadingFlagOn() {
-        featureFlag.setFlagOn(true);
+        featureFlaglist.get(0).setFlagOn(true);
         MeasureSelectedEvent evt = new MeasureSelectedEvent("measureId", "v1", "measure1", "name1", "sctyp1", true,
                 true, "", true, false, "TYPE1");
         MatContext.get().setCurrentMeasureInfo(evt);
@@ -33,7 +36,7 @@ public class MeasureComposerPresenterTest {
 
     @Test
     public void testHeadingFlagOff() {
-        featureFlag.setFlagOn(false);
+        featureFlaglist.get(0).setFlagOn(false);
         MeasureSelectedEvent evt = new MeasureSelectedEvent("measureId", "v1", "measure1", "name1", "sctyp1", true,
                 true, "", true, false, "TYPE1");
         MatContext.get().setCurrentMeasureInfo(evt);

--- a/src/test/java/mat/client/MeasureComposerPresenterTest.java
+++ b/src/test/java/mat/client/MeasureComposerPresenterTest.java
@@ -8,35 +8,33 @@ import org.junit.runner.RunWith;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import mat.client.event.MeasureSelectedEvent;
 import mat.client.shared.MatContext;
-import mat.model.FeatureFlag;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class MeasureComposerPresenterTest {
 
-    private List<FeatureFlag> featureFlaglist = new ArrayList<>();
-
-    @Before
-    public void setup() {
-        featureFlaglist.add(new FeatureFlag(1, "MAT_ON_FHIR", false));
-        MatContext.get().setFeatureFlags(featureFlaglist);
-    }
+    private Map<String, Boolean> featureFlagMap = new HashMap<>();
 
     @Test
     public void testHeadingFlagOn() {
-        featureFlaglist.get(0).setFlagOn(true);
+        featureFlagMap.put("MAT_ON_FHIR",true);
+        MatContext.get().setFeatureFlags(featureFlagMap);
+
         MeasureSelectedEvent evt = new MeasureSelectedEvent("measureId", "v1", "measure1", "name1", "sctyp1", true,
                 true, "", true, false, "TYPE1");
         MatContext.get().setCurrentMeasureInfo(evt);
+
         String headingValue = MeasureComposerPresenter.buildMeasureHeading("anyId");
         Assert.assertEquals("measure1 v1 (TYPE1)", headingValue);
     }
 
     @Test
     public void testHeadingFlagOff() {
-        featureFlaglist.get(0).setFlagOn(false);
+        featureFlagMap.put("MAT_ON_FHIR",false);
+        MatContext.get().setFeatureFlags(featureFlagMap);
+
         MeasureSelectedEvent evt = new MeasureSelectedEvent("measureId", "v1", "measure1", "name1", "sctyp1", true,
                 true, "", true, false, "TYPE1");
         MatContext.get().setCurrentMeasureInfo(evt);

--- a/src/test/java/mat/client/shared/MeasureLibraryResultTableTest.java
+++ b/src/test/java/mat/client/shared/MeasureLibraryResultTableTest.java
@@ -13,6 +13,7 @@ import com.google.gwt.view.client.CellPreviewEvent;
 import com.google.gwt.view.client.MultiSelectionModel;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import mat.client.measure.ManageMeasureSearchModel;
+import mat.client.util.FeatureFlagConstant;
 import mat.model.FeatureFlag;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,6 +37,7 @@ public class MeasureLibraryResultTableTest {
 
     private List<ManageMeasureSearchModel.Result> results;
     private ClickHandler clickHandler;
+    private List<FeatureFlag> featureFlaglist = new ArrayList<>();
 
     @Before
     public void setUp() {
@@ -61,10 +63,9 @@ public class MeasureLibraryResultTableTest {
         when(cellTable.getElement()).thenReturn(tbl);
         when(tbl.cast()).thenReturn(GWT.create(TableElement.class));
 
-        FeatureFlag featureFlag = new FeatureFlag();
-        featureFlag.setFlagOn(true);
-
-        MatContext.get().setMatOnFHIR(featureFlag);
+        featureFlaglist.add(new FeatureFlag(1, "MAT_ON_FHIR", false));
+        featureFlaglist.add(new FeatureFlag(2, "FHIR_EDIt", true));
+        MatContext.get().setFeatureFlags(featureFlaglist);
 
         cellTable = measureLibraryResultTable.addColumnToTable("Recent Activity", cellTable, results, false, fireEvent);
         assertNotNull(cellTable);

--- a/src/test/java/mat/client/shared/MeasureLibraryResultTableTest.java
+++ b/src/test/java/mat/client/shared/MeasureLibraryResultTableTest.java
@@ -13,15 +13,15 @@ import com.google.gwt.view.client.CellPreviewEvent;
 import com.google.gwt.view.client.MultiSelectionModel;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import mat.client.measure.ManageMeasureSearchModel;
-import mat.client.util.FeatureFlagConstant;
-import mat.model.FeatureFlag;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.*;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class MeasureLibraryResultTableTest {
@@ -37,7 +37,7 @@ public class MeasureLibraryResultTableTest {
 
     private List<ManageMeasureSearchModel.Result> results;
     private ClickHandler clickHandler;
-    private List<FeatureFlag> featureFlaglist = new ArrayList<>();
+    private Map<String, Boolean> featureFlagMap = new HashMap<>();
 
     @Before
     public void setUp() {
@@ -63,9 +63,9 @@ public class MeasureLibraryResultTableTest {
         when(cellTable.getElement()).thenReturn(tbl);
         when(tbl.cast()).thenReturn(GWT.create(TableElement.class));
 
-        featureFlaglist.add(new FeatureFlag(1, "MAT_ON_FHIR", false));
-        featureFlaglist.add(new FeatureFlag(2, "FHIR_EDIt", true));
-        MatContext.get().setFeatureFlags(featureFlaglist);
+        featureFlagMap.put("MAT_ON_FHIR", false);
+        featureFlagMap.put("FHIR_EDIt", true);
+        MatContext.get().setFeatureFlags(featureFlagMap);
 
         cellTable = measureLibraryResultTable.addColumnToTable("Recent Activity", cellTable, results, false, fireEvent);
         assertNotNull(cellTable);

--- a/src/test/java/mat/client/shared/MeasureLibraryResultTableTest.java
+++ b/src/test/java/mat/client/shared/MeasureLibraryResultTableTest.java
@@ -64,7 +64,6 @@ public class MeasureLibraryResultTableTest {
         when(tbl.cast()).thenReturn(GWT.create(TableElement.class));
 
         featureFlagMap.put("MAT_ON_FHIR", false);
-        featureFlagMap.put("FHIR_EDIt", true);
         MatContext.get().setFeatureFlags(featureFlagMap);
 
         cellTable = measureLibraryResultTable.addColumnToTable("Recent Activity", cellTable, results, false, fireEvent);

--- a/src/test/java/mat/server/FeatureFlagServiceImplTest.java
+++ b/src/test/java/mat/server/FeatureFlagServiceImplTest.java
@@ -26,11 +26,6 @@ class FeatureFlagServiceImplTest {
     @InjectMocks
     FeatureFlagServiceImpl featureFlagServiceImpl;
 
-    @Before
-    public void init() {
-        MockitoAnnotations.initMocks(this);
-    }
-
     @Test
     void findFeatureFlagTest() {
         List<FeatureFlag> featureFlaglist = new ArrayList<>();
@@ -39,7 +34,7 @@ class FeatureFlagServiceImplTest {
         featureFlaglist.add(new FeatureFlag(3, "FHIR_DELETE", false));
 
         Mockito.when(featureFlagDAO.findAllFeatureFlags()).thenReturn(featureFlaglist);
-        List<FeatureFlag> flagList = featureFlagServiceImpl.findFeatureFlag();
+        List<FeatureFlag> flagList = featureFlagServiceImpl.findFeatureFlags();
         assertEquals(3,flagList.size());
         Mockito.verify(featureFlagDAO, times(1)).findAllFeatureFlags();
     }

--- a/src/test/java/mat/server/FeatureFlagServiceImplTest.java
+++ b/src/test/java/mat/server/FeatureFlagServiceImplTest.java
@@ -2,17 +2,16 @@ package mat.server;
 
 import mat.dao.impl.FeatureFlagDAOImpl;
 import mat.model.FeatureFlag;
-import org.junit.Before;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.times;
@@ -34,8 +33,8 @@ class FeatureFlagServiceImplTest {
         featureFlaglist.add(new FeatureFlag(3, "FHIR_DELETE", false));
 
         Mockito.when(featureFlagDAO.findAllFeatureFlags()).thenReturn(featureFlaglist);
-        List<FeatureFlag> flagList = featureFlagServiceImpl.findFeatureFlags();
-        assertEquals(3,flagList.size());
+        Map<String, Boolean> featureFlagMap = featureFlagServiceImpl.findFeatureFlags();
+        assertEquals(3,featureFlagMap.size());
         Mockito.verify(featureFlagDAO, times(1)).findAllFeatureFlags();
     }
 }

--- a/src/test/java/mat/server/FeatureFlagServiceImplTest.java
+++ b/src/test/java/mat/server/FeatureFlagServiceImplTest.java
@@ -1,0 +1,46 @@
+package mat.server;
+
+import mat.dao.impl.FeatureFlagDAOImpl;
+import mat.model.FeatureFlag;
+import org.junit.Before;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class FeatureFlagServiceImplTest {
+
+    @Mock
+    FeatureFlagDAOImpl featureFlagDAO;
+
+    @InjectMocks
+    FeatureFlagServiceImpl featureFlagServiceImpl;
+
+    @Before
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    void findFeatureFlagTest() {
+        List<FeatureFlag> featureFlaglist = new ArrayList<>();
+        featureFlaglist.add(new FeatureFlag(1, "MAT_ON_FHIR", false));
+        featureFlaglist.add(new FeatureFlag(2, "FHIR_EDIt", true));
+        featureFlaglist.add(new FeatureFlag(3, "FHIR_DELETE", false));
+
+        Mockito.when(featureFlagDAO.findAllFeatureFlags()).thenReturn(featureFlaglist);
+        List<FeatureFlag> flagList = featureFlagServiceImpl.findFeatureFlag();
+        assertEquals(3,flagList.size());
+        Mockito.verify(featureFlagDAO, times(1)).findAllFeatureFlags();
+    }
+}

--- a/src/test/resources/mat-test.properties
+++ b/src/test/resources/mat-test.properties
@@ -1,4 +1,0 @@
-driverClassName = "com.mysql.jdbc.Driver"
-url = "jdbc:mysql://localhost:3306/test"
-username ="root"
-password = "password"

--- a/src/test/resources/mat-test.properties
+++ b/src/test/resources/mat-test.properties
@@ -1,0 +1,4 @@
+driverClassName = "com.mysql.jdbc.Driver"
+url = "jdbc:mysql://localhost:3306/test"
+username ="root"
+password = "password"


### PR DESCRIPTION
Added a new script to liquibase to insert new MVP Feature Flags into FEATURE_FLAGS table. All flags are set to "false" initially. "/src/main/java/liquibase/addMVPFeatureFlags.xml"

Retrieving all flags from Feature_Flag table and storing them as a list. Used inherited class GenericDAO to find all records. 

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/57495404/71294002-247b5700-2345-11ea-8c50-1a73c4504464.png">

All Flag constants are created and could be used to know if the flag is on/off "src/main/java/mat/client/util/FeatureFlagConstant.java"

`MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.MAT_ON_FHIR)` returns a Boolean value stating whether the specific flag is On/Off