### PR TITLE
Feature/mat 316 implement fhir edit feature flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -500,9 +500,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>5.2.2.RELEASE</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -499,6 +499,11 @@
             <version>0.8.13</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>5.2.2.RELEASE</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/mat/client/measure/ManageMeasureSearchModel.java
+++ b/src/main/java/mat/client/measure/ManageMeasureSearchModel.java
@@ -7,8 +7,11 @@ import java.util.Objects;
 
 import com.google.gwt.user.client.rpc.IsSerializable;
 import com.google.gwt.user.client.ui.Widget;
+import mat.client.shared.MatContext;
 import mat.client.shared.search.SearchResults;
+import mat.client.util.FeatureFlagConstant;
 import mat.model.LockedUserInfo;
+import mat.shared.model.util.MeasureDetailsUtil;
 
 /**
  * The Class ManageMeasureSearchModel.
@@ -353,6 +356,9 @@ public class ManageMeasureSearchModel implements IsSerializable, SearchResults<M
             this.isEditable = isEditable;
         }
 
+        public boolean isFhirEditableFeatureFlag() {
+            return MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.FHIR_EDIT) || (this.draft && MeasureDetailsUtil.QDM.equals(this.measureModel));
+        }
         /**
          * Checks if is clonable.
          *

--- a/src/main/java/mat/client/measure/ManageMeasureSearchModel.java
+++ b/src/main/java/mat/client/measure/ManageMeasureSearchModel.java
@@ -77,6 +77,8 @@ public class ManageMeasureSearchModel implements IsSerializable, SearchResults<M
 
         private int clickCount = 0;
 
+        private boolean isFhirEditorViewable;
+
         public Result() {
         }
 
@@ -720,6 +722,15 @@ public class ManageMeasureSearchModel implements IsSerializable, SearchResults<M
         public void incrementClickCount() {
             this.clickCount++;
         }
+
+        public void setFhirEditOrViewable(boolean isFhirEditorViewable) {
+            this.isFhirEditorViewable = isFhirEditorViewable;
+        }
+
+        public boolean isFhirEditOrViewable() {
+            return this.isFhirEditorViewable;
+        }
+
     }
 
     /**

--- a/src/main/java/mat/client/measure/ManageMeasureSearchModel.java
+++ b/src/main/java/mat/client/measure/ManageMeasureSearchModel.java
@@ -356,9 +356,6 @@ public class ManageMeasureSearchModel implements IsSerializable, SearchResults<M
             this.isEditable = isEditable;
         }
 
-        public boolean isFhirEditableFeatureFlag() {
-            return MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.FHIR_EDIT) || (this.draft && MeasureDetailsUtil.QDM.equals(this.measureModel));
-        }
         /**
          * Checks if is clonable.
          *

--- a/src/main/java/mat/client/shared/CQLLibraryResultTable.java
+++ b/src/main/java/mat/client/shared/CQLLibraryResultTable.java
@@ -66,7 +66,7 @@ public class CQLLibraryResultTable {
                 if (object.getLastClick() < System.currentTimeMillis() - DELAY_TIME) {
                     object.setSelected(!object.isSelected());
                     selectionModel.setSelected(object, object.isSelected());
-                } else {
+                } else if (object.isFhirEditableFeatureFlag()) {
                     SelectionEvent.fire(fireEvent, object);
                 }
                 object.setLastClick(System.currentTimeMillis());
@@ -92,7 +92,7 @@ public class CQLLibraryResultTable {
                 if (object.getLastClick() < System.currentTimeMillis() - DELAY_TIME) {
                     object.setSelected(!object.isSelected());
                     selectionModel.setSelected(object, object.isSelected());
-                } else {
+                } else if (object.isFhirEditableFeatureFlag()) {
                     SelectionEvent.fire(fireEvent, object);
                 }
                 object.setLastClick(System.currentTimeMillis());
@@ -117,7 +117,7 @@ public class CQLLibraryResultTable {
                 if (object.getLastClick() < System.currentTimeMillis() - DELAY_TIME) {
                     object.setSelected(!object.isSelected());
                     selectionModel.setSelected(object, object.isSelected());
-                } else {
+                } else if (object.isFhirEditableFeatureFlag()) {
                     SelectionEvent.fire(fireEvent, object);
                 }
                 object.setLastClick(System.currentTimeMillis());

--- a/src/main/java/mat/client/shared/CQLLibraryResultTable.java
+++ b/src/main/java/mat/client/shared/CQLLibraryResultTable.java
@@ -66,7 +66,7 @@ public class CQLLibraryResultTable {
                 if (object.getLastClick() < System.currentTimeMillis() - DELAY_TIME) {
                     object.setSelected(!object.isSelected());
                     selectionModel.setSelected(object, object.isSelected());
-                } else if (object.isFhirEditableFeatureFlag()) {
+                } else if (object.isEditable()) {
                     SelectionEvent.fire(fireEvent, object);
                 }
                 object.setLastClick(System.currentTimeMillis());
@@ -92,7 +92,7 @@ public class CQLLibraryResultTable {
                 if (object.getLastClick() < System.currentTimeMillis() - DELAY_TIME) {
                     object.setSelected(!object.isSelected());
                     selectionModel.setSelected(object, object.isSelected());
-                } else if (object.isFhirEditableFeatureFlag()) {
+                } else if (object.isEditable()) {
                     SelectionEvent.fire(fireEvent, object);
                 }
                 object.setLastClick(System.currentTimeMillis());
@@ -117,7 +117,7 @@ public class CQLLibraryResultTable {
                 if (object.getLastClick() < System.currentTimeMillis() - DELAY_TIME) {
                     object.setSelected(!object.isSelected());
                     selectionModel.setSelected(object, object.isSelected());
-                } else if (object.isFhirEditableFeatureFlag()) {
+                } else if (object.isEditable()) {
                     SelectionEvent.fire(fireEvent, object);
                 }
                 object.setLastClick(System.currentTimeMillis());

--- a/src/main/java/mat/client/shared/CQLLibraryResultTable.java
+++ b/src/main/java/mat/client/shared/CQLLibraryResultTable.java
@@ -66,7 +66,7 @@ public class CQLLibraryResultTable {
                 if (object.getLastClick() < System.currentTimeMillis() - DELAY_TIME) {
                     object.setSelected(!object.isSelected());
                     selectionModel.setSelected(object, object.isSelected());
-                } else if (object.isEditable()) {
+                } else if (object.isFhirEditOrViewable()) {
                     SelectionEvent.fire(fireEvent, object);
                 }
                 object.setLastClick(System.currentTimeMillis());
@@ -92,7 +92,7 @@ public class CQLLibraryResultTable {
                 if (object.getLastClick() < System.currentTimeMillis() - DELAY_TIME) {
                     object.setSelected(!object.isSelected());
                     selectionModel.setSelected(object, object.isSelected());
-                } else if (object.isEditable()) {
+                } else if (object.isFhirEditOrViewable()) {
                     SelectionEvent.fire(fireEvent, object);
                 }
                 object.setLastClick(System.currentTimeMillis());
@@ -117,7 +117,7 @@ public class CQLLibraryResultTable {
                 if (object.getLastClick() < System.currentTimeMillis() - DELAY_TIME) {
                     object.setSelected(!object.isSelected());
                     selectionModel.setSelected(object, object.isSelected());
-                } else if (object.isEditable()) {
+                } else if (object.isFhirEditOrViewable()) {
                     SelectionEvent.fire(fireEvent, object);
                 }
                 object.setLastClick(System.currentTimeMillis());

--- a/src/main/java/mat/client/shared/CQLibraryGridToolbar.java
+++ b/src/main/java/mat/client/shared/CQLibraryGridToolbar.java
@@ -135,7 +135,7 @@ public class CQLibraryGridToolbar extends HorizontalFlowPanel {
         historyButton.setIcon(IconType.CLOCK_O);
         historyButton.setTitle(CLICK_TO_VIEW_HISTORY_TITLE);
 
-        if (selectedItem.isEditable()) {
+        if (selectedItem.isEditable() && selectedItem.isFhirEditableFeatureFlag()) {
             if (selectedItem.isLocked()) {
                 editOrViewButton.setText(EDIT_TEXT);
                 editOrViewButton.setEnabled(false);

--- a/src/main/java/mat/client/shared/CQLibraryGridToolbar.java
+++ b/src/main/java/mat/client/shared/CQLibraryGridToolbar.java
@@ -1,6 +1,5 @@
 package mat.client.shared;
 
-
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.constants.ButtonType;
 import org.gwtbootstrap3.client.ui.constants.IconType;
@@ -135,7 +134,7 @@ public class CQLibraryGridToolbar extends HorizontalFlowPanel {
         historyButton.setIcon(IconType.CLOCK_O);
         historyButton.setTitle(CLICK_TO_VIEW_HISTORY_TITLE);
 
-        if (selectedItem.isEditable()) {
+        if (selectedItem.isEditable() && selectedItem.isFhirEditOrViewable()) {
             if (selectedItem.isLocked()) {
                 editOrViewButton.setText(EDIT_TEXT);
                 editOrViewButton.setEnabled(false);
@@ -147,11 +146,13 @@ public class CQLibraryGridToolbar extends HorizontalFlowPanel {
                 editOrViewButton.setIcon(IconType.PENCIL);
                 editOrViewButton.setTitle(CLICK_TO_EDIT_TITLE);
             }
-        } else {
+        } else if (!selectedItem.isEditable() && selectedItem.isFhirEditOrViewable()) {
             editOrViewButton.setText(VIEW_TEXT);
             editOrViewButton.setEnabled(true);
             editOrViewButton.setIcon(IconType.EYE);
             editOrViewButton.setTitle("Read-Only");
+        } else {
+            editOrViewButton.setEnabled(false);
         }
 
         shareButton.setText(SHARE_TEXT);

--- a/src/main/java/mat/client/shared/CQLibraryGridToolbar.java
+++ b/src/main/java/mat/client/shared/CQLibraryGridToolbar.java
@@ -135,7 +135,7 @@ public class CQLibraryGridToolbar extends HorizontalFlowPanel {
         historyButton.setIcon(IconType.CLOCK_O);
         historyButton.setTitle(CLICK_TO_VIEW_HISTORY_TITLE);
 
-        if (selectedItem.isEditable() && selectedItem.isFhirEditableFeatureFlag()) {
+        if (selectedItem.isEditable()) {
             if (selectedItem.isLocked()) {
                 editOrViewButton.setText(EDIT_TEXT);
                 editOrViewButton.setEnabled(false);

--- a/src/main/java/mat/client/shared/MatContext.java
+++ b/src/main/java/mat/client/shared/MatContext.java
@@ -230,7 +230,7 @@ public class MatContext implements IsSerializable {
 
     private Map<String, String> expressionToReturnTypeMap = new HashMap<>();
 
-    private Map<String, Boolean> featureFlagMap;
+	private Map<String, Boolean> featureFlagMap = new HashMap<>();
 
     public void clearDVIMessages() {
         if (qdsView != null) {

--- a/src/main/java/mat/client/shared/MeasureLibraryGridToolbar.java
+++ b/src/main/java/mat/client/shared/MeasureLibraryGridToolbar.java
@@ -113,7 +113,7 @@ public class MeasureLibraryGridToolbar extends HorizontalFlowPanel {
 
         fhirValidationButton.setEnabled(selectedItem.isValidatable());
 
-        if (selectedItem.isEditable()) {
+        if (selectedItem.isEditable() && selectedItem.isFhirEditableFeatureFlag()) {
             if (selectedItem.isMeasureLocked()) {
                 String emailAddress = selectedItem.getLockedUserInfo().getEmailAddress();
                 editOrViewButton.setTitle("Measure in use by " + emailAddress);

--- a/src/main/java/mat/client/shared/MeasureLibraryGridToolbar.java
+++ b/src/main/java/mat/client/shared/MeasureLibraryGridToolbar.java
@@ -113,7 +113,7 @@ public class MeasureLibraryGridToolbar extends HorizontalFlowPanel {
 
         fhirValidationButton.setEnabled(selectedItem.isValidatable());
 
-        if (selectedItem.isEditable()) {
+        if (selectedItem.isEditable() && selectedItem.isFhirEditOrViewable()) {
             if (selectedItem.isMeasureLocked()) {
                 String emailAddress = selectedItem.getLockedUserInfo().getEmailAddress();
                 editOrViewButton.setTitle("Measure in use by " + emailAddress);
@@ -123,11 +123,13 @@ public class MeasureLibraryGridToolbar extends HorizontalFlowPanel {
                 editOrViewButton.setIcon(IconType.PENCIL);
                 editOrViewButton.setEnabled(true);
             }
-        } else {
+        } else if (!selectedItem.isEditable() && selectedItem.isFhirEditOrViewable()) {
             editOrViewButton.setText(VIEW_TEXT);
             editOrViewButton.setEnabled(true);
             editOrViewButton.setTitle("Read-Only");
             editOrViewButton.setIcon(IconType.EYE);
+        } else {
+            editOrViewButton.setEnabled(false);
         }
 
         shareButton.setEnabled(selectedItem.isSharable());

--- a/src/main/java/mat/client/shared/MeasureLibraryGridToolbar.java
+++ b/src/main/java/mat/client/shared/MeasureLibraryGridToolbar.java
@@ -113,7 +113,7 @@ public class MeasureLibraryGridToolbar extends HorizontalFlowPanel {
 
         fhirValidationButton.setEnabled(selectedItem.isValidatable());
 
-        if (selectedItem.isEditable() && selectedItem.isFhirEditableFeatureFlag()) {
+        if (selectedItem.isEditable()) {
             if (selectedItem.isMeasureLocked()) {
                 String emailAddress = selectedItem.getLockedUserInfo().getEmailAddress();
                 editOrViewButton.setTitle("Measure in use by " + emailAddress);

--- a/src/main/java/mat/client/shared/MeasureLibraryResultTable.java
+++ b/src/main/java/mat/client/shared/MeasureLibraryResultTable.java
@@ -104,7 +104,7 @@ public class MeasureLibraryResultTable {
                         }
                     };
                     singleClickTimer.schedule(MOUSE_CLICK_DELAY);
-                } else if (obj.getClickCount() == 2) {
+                } else if (obj.getClickCount() == 2 && obj.isFhirEditableFeatureFlag()) {
                     singleClickTimer.cancel();
                     obj.setClickCount(0);
                     SelectionEvent.fire(fireEvent, obj);

--- a/src/main/java/mat/client/shared/MeasureLibraryResultTable.java
+++ b/src/main/java/mat/client/shared/MeasureLibraryResultTable.java
@@ -104,7 +104,7 @@ public class MeasureLibraryResultTable {
                         }
                     };
                     singleClickTimer.schedule(MOUSE_CLICK_DELAY);
-                } else if (obj.getClickCount() == 2  && obj.isEditable()) {
+                } else if (obj.getClickCount() == 2  && obj.isFhirEditOrViewable()) {
                     singleClickTimer.cancel();
                     obj.setClickCount(0);
                     SelectionEvent.fire(fireEvent, obj);

--- a/src/main/java/mat/client/shared/MeasureLibraryResultTable.java
+++ b/src/main/java/mat/client/shared/MeasureLibraryResultTable.java
@@ -104,7 +104,7 @@ public class MeasureLibraryResultTable {
                         }
                     };
                     singleClickTimer.schedule(MOUSE_CLICK_DELAY);
-                } else if (obj.getClickCount() == 2 && obj.isFhirEditableFeatureFlag()) {
+                } else if (obj.getClickCount() == 2  && obj.isEditable()) {
                     singleClickTimer.cancel();
                     obj.setClickCount(0);
                     SelectionEvent.fire(fireEvent, obj);

--- a/src/main/java/mat/dao/impl/FeatureFlagDAOImpl.java
+++ b/src/main/java/mat/dao/impl/FeatureFlagDAOImpl.java
@@ -6,6 +6,7 @@ import mat.model.FeatureFlag;
 import org.apache.commons.collections.CollectionUtils;
 import org.hibernate.SessionFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 
 import java.util.Collections;
@@ -21,6 +22,7 @@ public class FeatureFlagDAOImpl extends GenericDAO<FeatureFlag, String> implemen
     }
 
     @Override
+    @Cacheable("featureFlags")
     public List<FeatureFlag> findAllFeatureFlags() {
         final List<FeatureFlag> dataTypeList = find();
         return CollectionUtils.isNotEmpty(dataTypeList) ? dataTypeList : Collections.EMPTY_LIST;

--- a/src/main/java/mat/model/FeatureFlag.java
+++ b/src/main/java/mat/model/FeatureFlag.java
@@ -46,7 +46,7 @@ public class FeatureFlag implements java.io.Serializable {
     }
 
     @Column(name = "FLAG_ON")
-    public boolean getFlagOn() {
+    public boolean isFlagOn() {
         return flagOn;
     }
 

--- a/src/main/java/mat/model/cql/CQLLibraryDataSetObject.java
+++ b/src/main/java/mat/model/cql/CQLLibraryDataSetObject.java
@@ -39,6 +39,7 @@ public class CQLLibraryDataSetObject implements IsSerializable, BaseModel {
     private boolean isDeletable;
     private String libraryModelType;
     private long lastClick;
+    private boolean isFhirEditorViewable;
 
     private List<CQLError> cqlErrors = new ArrayList<>();
 
@@ -313,6 +314,14 @@ public class CQLLibraryDataSetObject implements IsSerializable, BaseModel {
 
     public void setLibraryModelType(String libraryModelType) {
         this.libraryModelType = libraryModelType;
+    }
+
+    public void setFhirEditOrViewable(boolean isFhirEditorViewable) {
+        this.isFhirEditorViewable = isFhirEditorViewable;
+    }
+
+    public boolean isFhirEditOrViewable() {
+        return this.isFhirEditorViewable;
     }
 
 }

--- a/src/main/java/mat/model/cql/CQLLibraryDataSetObject.java
+++ b/src/main/java/mat/model/cql/CQLLibraryDataSetObject.java
@@ -5,12 +5,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.gwt.user.client.rpc.IsSerializable;
-import mat.client.shared.MatContext;
-import mat.client.util.FeatureFlagConstant;
 import mat.model.BaseModel;
 import mat.model.LockedUserInfo;
 import mat.shared.CQLError;
-import mat.shared.model.util.MeasureDetailsUtil;
 
 public class CQLLibraryDataSetObject implements IsSerializable, BaseModel {
     private String id;
@@ -316,10 +313,6 @@ public class CQLLibraryDataSetObject implements IsSerializable, BaseModel {
 
     public void setLibraryModelType(String libraryModelType) {
         this.libraryModelType = libraryModelType;
-    }
-
-    public boolean isFhirEditableFeatureFlag() {
-        return MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.FHIR_EDIT) || (this.isDraft && MeasureDetailsUtil.QDM.equals(this.libraryModelType));
     }
 
 }

--- a/src/main/java/mat/model/cql/CQLLibraryDataSetObject.java
+++ b/src/main/java/mat/model/cql/CQLLibraryDataSetObject.java
@@ -5,9 +5,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.gwt.user.client.rpc.IsSerializable;
+import mat.client.shared.MatContext;
+import mat.client.util.FeatureFlagConstant;
 import mat.model.BaseModel;
 import mat.model.LockedUserInfo;
 import mat.shared.CQLError;
+import mat.shared.model.util.MeasureDetailsUtil;
 
 public class CQLLibraryDataSetObject implements IsSerializable, BaseModel {
     private String id;
@@ -313,6 +316,10 @@ public class CQLLibraryDataSetObject implements IsSerializable, BaseModel {
 
     public void setLibraryModelType(String libraryModelType) {
         this.libraryModelType = libraryModelType;
+    }
+
+    public boolean isFhirEditableFeatureFlag() {
+        return MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.FHIR_EDIT) || (this.isDraft && MeasureDetailsUtil.QDM.equals(this.libraryModelType));
     }
 
 }

--- a/src/main/java/mat/server/Application.java
+++ b/src/main/java/mat/server/Application.java
@@ -20,6 +20,8 @@ import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.jdbc.datasource.lookup.JndiDataSourceLookup;
 import org.springframework.orm.hibernate5.HibernateTransactionManager;
 import org.springframework.orm.hibernate5.LocalSessionFactoryBean;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -40,6 +42,7 @@ import mat.server.twofactorauth.OTPValidatorInterfaceForUser;
 @EnableTransactionManagement
 @EnableWebSecurity
 @EnableCaching
+@EnableScheduling
 public class Application extends WebSecurityConfigurerAdapter {
 
     @Value("${ALGORITHM:}")
@@ -174,5 +177,10 @@ public class Application extends WebSecurityConfigurerAdapter {
         final SimpleCacheManager cacheManager = new SimpleCacheManager();
         cacheManager.setCaches(Arrays.asList(new ConcurrentMapCache("featureFlags")));
         return cacheManager;
+    }
+
+    @Scheduled(fixedRateString = "${mat.cache.expiry.time}")          // At every 5th min
+    public void clearCacheSchedule(){
+        cacheManager().getCache("featureFlags").clear();
     }
 }

--- a/src/main/java/mat/server/Application.java
+++ b/src/main/java/mat/server/Application.java
@@ -1,5 +1,6 @@
 package mat.server;
 
+import java.util.Arrays;
 import java.util.Properties;
 
 import javax.sql.DataSource;
@@ -7,6 +8,10 @@ import javax.sql.DataSource;
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -34,6 +39,7 @@ import mat.server.twofactorauth.OTPValidatorInterfaceForUser;
 @PropertySource("classpath:MAT.properties")
 @EnableTransactionManagement
 @EnableWebSecurity
+@EnableCaching
 public class Application extends WebSecurityConfigurerAdapter {
 
     @Value("${ALGORITHM:}")
@@ -161,5 +167,12 @@ public class Application extends WebSecurityConfigurerAdapter {
                         .build();
 
         return new InMemoryUserDetailsManager(user);
+    }
+
+    @Bean
+    public CacheManager cacheManager() {
+        final SimpleCacheManager cacheManager = new SimpleCacheManager();
+        cacheManager.setCaches(Arrays.asList(new ConcurrentMapCache("featureFlags")));
+        return cacheManager;
     }
 }

--- a/src/main/java/mat/server/Application.java
+++ b/src/main/java/mat/server/Application.java
@@ -179,7 +179,7 @@ public class Application extends WebSecurityConfigurerAdapter {
         return cacheManager;
     }
 
-    @Scheduled(fixedRateString = "${mat.cache.expiry.time}")          // At every 5th min
+    @Scheduled(fixedRateString = "${mat.cache.expiry.time}")
     public void clearCacheSchedule(){
         cacheManager().getCache("featureFlags").clear();
     }

--- a/src/main/java/mat/server/CQLLibraryService.java
+++ b/src/main/java/mat/server/CQLLibraryService.java
@@ -255,13 +255,12 @@ public class CQLLibraryService extends SpringRemoteServiceServlet implements CQL
         dataSetObject.setVersion(formattedVersion);
         dataSetObject.setEditable(MatContextServiceUtil.get()
                 .isCurrentCQLLibraryEditable(cqlLibraryDAO, cqlLibrary.getId()));
-
+        dataSetObject.setFhirEditOrViewable(MatContextServiceUtil.get().isCqlLibraryModelEditable(cqlLibrary.getLibraryModelType()));
 
         List<CQLLibrary> libraryList = new ArrayList<>();
         libraryList.add(cqlLibrary);
         List<CQLLibrary> cqlLibraryFamily = cqlLibraryDAO.getAllLibrariesInSet(libraryList);
         Boolean isEditableForVersion = MatContextServiceUtil.get().isCurrentCQLLibraryEditable(cqlLibraryDAO, cqlLibrary.getId(), false);
-
         if (!dataSetObject.isLocked() && isEditableForVersion) {
             caclulateVersionAndDraft(dataSetObject, cqlLibraryFamily);
         }
@@ -1411,7 +1410,6 @@ public class CQLLibraryService extends SpringRemoteServiceServlet implements CQL
 
         boolean isOwner = user.getId().equals(dto.getOwnerUserId());
         boolean isSuperUser = SecurityRole.SUPER_USER_ROLE.equals(user.getSecurityRole().getDescription());
-
         CQLLibraryDataSetObject dataObject = new CQLLibraryDataSetObject();
         String formattedVersion = MeasureUtility.getVersionTextWithRevisionNumber(dto.getVersion(),
                 dto.getRevisionNumber(), dto.isDraft());
@@ -1419,7 +1417,6 @@ public class CQLLibraryService extends SpringRemoteServiceServlet implements CQL
         dataObject.setId(dto.getCqlLibraryId());
         dataObject.setCqlName(dto.getCqlLibraryName());
         dataObject.setVersion(formattedVersion);
-        dataObject.setLibraryModelType(dto.getLibraryModelType());
         dataObject.setDraft(dto.isDraft());
         dataObject.setFinalizedDate(dto.getFinalizedDate());
         dataObject.setLocked(dto.isLocked());
@@ -1432,6 +1429,7 @@ public class CQLLibraryService extends SpringRemoteServiceServlet implements CQL
         dataObject.setCqlSetId(dto.getCqlLibrarySetId());
         dataObject.setEditable(MatContextServiceUtil.get().isCurrentCQLLibraryEditable(
                 cqlLibraryDAO, dto.getCqlLibraryId()));
+        dataObject.setFhirEditOrViewable(MatContextServiceUtil.get().isCqlLibraryModelEditable(dto.getLibraryModelType()));
         dataObject.setDraftable(dto.isDraftable());
         dataObject.setVersionable(dto.isVersionable());
         dataObject.setLibraryModelType(dto.getLibraryModelType());

--- a/src/main/java/mat/server/FeatureFlagServiceImpl.java
+++ b/src/main/java/mat/server/FeatureFlagServiceImpl.java
@@ -1,15 +1,12 @@
 package mat.server;
 
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.stereotype.Service;
-
 import mat.client.featureFlag.service.FeatureFlagService;
 import mat.dao.FeatureFlagDAO;
 import mat.model.FeatureFlag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -19,18 +16,14 @@ public class FeatureFlagServiceImpl extends SpringRemoteServiceServlet implement
 
 	private static final long serialVersionUID = 1L;
 
-	Map<String, Boolean> featureFlagMap = new HashMap<>();
-
 	@Autowired
 	private FeatureFlagDAO featureFlagDAO;
 
 	@Override
-	@Cacheable("featureFlags")
 	public Map<String, Boolean> findFeatureFlags() {
 		List<FeatureFlag> featureFlagList = featureFlagDAO.findAllFeatureFlags();
-		featureFlagMap  = featureFlagList.stream()
-				.collect(Collectors.toMap(f -> f.getFlagName(), v -> v.getFlagOn()));
-		return featureFlagMap;
+		return featureFlagList.stream()
+				.collect(Collectors.toMap(FeatureFlag::getFlagName, FeatureFlag::isFlagOn));
 	}
 
 }

--- a/src/main/java/mat/server/FeatureFlagServiceImpl.java
+++ b/src/main/java/mat/server/FeatureFlagServiceImpl.java
@@ -2,6 +2,7 @@ package mat.server;
 
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import mat.client.featureFlag.service.FeatureFlagService;
@@ -24,6 +25,7 @@ public class FeatureFlagServiceImpl extends SpringRemoteServiceServlet implement
 	FeatureFlagDAO featureFlagDAO;
 
 	@Override
+	@Cacheable("featureFlags")
 	public Map<String, Boolean> findFeatureFlags() {
 		List<FeatureFlag> featureFlagList = featureFlagDAO.findAllFeatureFlags();
 		featureFlagMap  = featureFlagList.stream()

--- a/src/main/java/mat/server/FeatureFlagServiceImpl.java
+++ b/src/main/java/mat/server/FeatureFlagServiceImpl.java
@@ -22,7 +22,7 @@ public class FeatureFlagServiceImpl extends SpringRemoteServiceServlet implement
 	Map<String, Boolean> featureFlagMap = new HashMap<>();
 
 	@Autowired
-	FeatureFlagDAO featureFlagDAO;
+	private FeatureFlagDAO featureFlagDAO;
 
 	@Override
 	@Cacheable("featureFlags")

--- a/src/main/java/mat/server/MeasureLibraryServiceImpl.java
+++ b/src/main/java/mat/server/MeasureLibraryServiceImpl.java
@@ -958,6 +958,7 @@ public class MeasureLibraryServiceImpl implements MeasureLibraryService {
         detail.setClonable(isClonable);
 
         detail.setEditable(MatContextServiceUtil.get().isCurrentMeasureEditable(measureDAO, dto.getMeasureId()));
+        detail.setFhirEditOrViewable(MatContextServiceUtil.get().isMeasureModelEditable(dto.getMeasureModel()));
         detail.setExportable(dto.isPackaged());
         detail.setFhirConvertible(MatContextServiceUtil.get().isMeasureConvertible(measure));
         detail.setHqmfReleaseVersion(measure.getReleaseVersion());
@@ -1120,6 +1121,7 @@ public class MeasureLibraryServiceImpl implements MeasureLibraryService {
         detail.setMeasureLocked(isLocked);
         boolean isEditable = MatContextServiceUtil.get().isCurrentMeasureEditable(measureDAO, measure.getId());
         detail.setEditable(isEditable);
+        detail.setFhirEditOrViewable(MatContextServiceUtil.get().isMeasureModelEditable(measure.getMeasureModel()));
         detail.setPatientBased(measure.getPatientBased());
         boolean isOwner = measure.getOwner().getId().equals(LoggedInUserUtil.getLoggedInUser());
         String measureReleaseVersion = StringUtils.trimToEmpty(measure.getReleaseVersion());

--- a/src/main/java/mat/server/service/impl/MatContextServiceUtil.java
+++ b/src/main/java/mat/server/service/impl/MatContextServiceUtil.java
@@ -29,7 +29,7 @@ public class MatContextServiceUtil implements InitializingBean {
     private static MatContextServiceUtil instance;
 
     @Autowired
-    FeatureFlagService featureFlag;
+    private FeatureFlagService featureFlag;
 
     @Override
     public void afterPropertiesSet() {
@@ -81,7 +81,7 @@ public class MatContextServiceUtil implements InitializingBean {
         if (shareLevel != null) {
             isSharedToEdit = ShareLevel.MODIFY_ID.equals(shareLevel.getId());
         }
-        if(isMeasureEditable(measure)) {
+        if(isMeasureModelEditable(measure)) {
             isEditable = (isOwner || isSuperUser || isSharedToEdit);
         }
 
@@ -154,7 +154,7 @@ public class MatContextServiceUtil implements InitializingBean {
             isSharedToEdit = ShareLevel.MODIFY_ID.equals(shareLevel.getId());
         }
 
-        if(isCqlLibraryEditable(cqlLibrary)) {
+        if(isCqlLibraryModelEditable(cqlLibrary)) {
             isEditable = (isOwner || isSuperUser || isSharedToEdit);
         }
 
@@ -228,11 +228,11 @@ public class MatContextServiceUtil implements InitializingBean {
         }
     }
 
-    public boolean isMeasureEditable(Measure measure) {
+    public boolean isMeasureModelEditable(Measure measure) {
         return featureFlag.findFeatureFlags().getOrDefault(FeatureFlagConstant.FHIR_EDIT, false) || MeasureDetailsUtil.QDM.equals(measure.getMeasureModel());
     }
 
-    public boolean isCqlLibraryEditable(CQLLibrary cqlLibrary) {
+    public boolean isCqlLibraryModelEditable(CQLLibrary cqlLibrary) {
         return featureFlag.findFeatureFlags().getOrDefault(FeatureFlagConstant.FHIR_EDIT, false) || MeasureDetailsUtil.QDM.equals(cqlLibrary.getLibraryModelType());
     }
 }

--- a/src/main/java/mat/server/service/impl/MatContextServiceUtil.java
+++ b/src/main/java/mat/server/service/impl/MatContextServiceUtil.java
@@ -29,7 +29,7 @@ public class MatContextServiceUtil implements InitializingBean {
     private static MatContextServiceUtil instance;
 
     @Autowired
-    private FeatureFlagService featureFlag;
+    private FeatureFlagService featureFlagService;
 
     @Override
     public void afterPropertiesSet() {
@@ -81,9 +81,7 @@ public class MatContextServiceUtil implements InitializingBean {
         if (shareLevel != null) {
             isSharedToEdit = ShareLevel.MODIFY_ID.equals(shareLevel.getId());
         }
-        if(isMeasureModelEditable(measure)) {
-            isEditable = (isOwner || isSuperUser || isSharedToEdit);
-        }
+        isEditable = (isOwner || isSuperUser || isSharedToEdit);
 
         if (checkForDraft) {
             isEditable = isEditable && dto.isDraft();
@@ -153,10 +151,7 @@ public class MatContextServiceUtil implements InitializingBean {
         if (shareLevel != null) {
             isSharedToEdit = ShareLevel.MODIFY_ID.equals(shareLevel.getId());
         }
-
-        if(isCqlLibraryModelEditable(cqlLibrary)) {
-            isEditable = (isOwner || isSuperUser || isSharedToEdit);
-        }
+        isEditable = (isOwner || isSuperUser || isSharedToEdit);
 
         if (checkForDraft) {
             isEditable = isEditable && dto.isDraft();
@@ -228,11 +223,11 @@ public class MatContextServiceUtil implements InitializingBean {
         }
     }
 
-    public boolean isMeasureModelEditable(Measure measure) {
-        return featureFlag.findFeatureFlags().getOrDefault(FeatureFlagConstant.FHIR_EDIT, false) || MeasureDetailsUtil.QDM.equals(measure.getMeasureModel());
+    public boolean isMeasureModelEditable(String modelType) {
+        return featureFlagService.findFeatureFlags().getOrDefault(FeatureFlagConstant.FHIR_EDIT, false) || !MeasureDetailsUtil.FHIR.equals(modelType);
     }
 
-    public boolean isCqlLibraryModelEditable(CQLLibrary cqlLibrary) {
-        return featureFlag.findFeatureFlags().getOrDefault(FeatureFlagConstant.FHIR_EDIT, false) || MeasureDetailsUtil.QDM.equals(cqlLibrary.getLibraryModelType());
+    public boolean isCqlLibraryModelEditable(String modelType) {
+        return featureFlagService.findFeatureFlags().getOrDefault(FeatureFlagConstant.FHIR_EDIT, false) || !MeasureDetailsUtil.FHIR.equals(modelType);
     }
 }

--- a/src/main/java/mat/server/service/impl/MatContextServiceUtil.java
+++ b/src/main/java/mat/server/service/impl/MatContextServiceUtil.java
@@ -1,9 +1,6 @@
 package mat.server.service.impl;
 
 import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.Map;
-
 import mat.client.featureFlag.service.FeatureFlagService;
 import mat.client.util.FeatureFlagConstant;
 import mat.dao.UserDAO;
@@ -38,8 +35,6 @@ public class MatContextServiceUtil implements InitializingBean {
     public void afterPropertiesSet() {
         instance = this;
     }
-
-    private Map<String, Boolean> featureFlagMap = new HashMap<>();
 
     /**
      * Gets the.
@@ -234,12 +229,10 @@ public class MatContextServiceUtil implements InitializingBean {
     }
 
     public boolean isMeasureEditable(Measure measure) {
-        featureFlagMap = featureFlag.findFeatureFlags();
-        return featureFlagMap.getOrDefault(FeatureFlagConstant.FHIR_EDIT, false) || MeasureDetailsUtil.QDM.equals(measure.getMeasureModel());
+        return featureFlag.findFeatureFlags().getOrDefault(FeatureFlagConstant.FHIR_EDIT, false) || MeasureDetailsUtil.QDM.equals(measure.getMeasureModel());
     }
 
     public boolean isCqlLibraryEditable(CQLLibrary cqlLibrary) {
-        featureFlagMap = featureFlag.findFeatureFlags();
-        return featureFlagMap.getOrDefault(FeatureFlagConstant.FHIR_EDIT, false) || MeasureDetailsUtil.QDM.equals(cqlLibrary.getLibraryModelType());
+        return featureFlag.findFeatureFlags().getOrDefault(FeatureFlagConstant.FHIR_EDIT, false) || MeasureDetailsUtil.QDM.equals(cqlLibrary.getLibraryModelType());
     }
 }

--- a/src/main/java/mat/server/service/impl/MatContextServiceUtil.java
+++ b/src/main/java/mat/server/service/impl/MatContextServiceUtil.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 
+import mat.client.featureFlag.service.FeatureFlagService;
 import mat.client.util.FeatureFlagConstant;
 import mat.dao.UserDAO;
 import mat.dao.clause.CQLLibraryDAO;
@@ -14,7 +15,6 @@ import mat.model.clause.Measure;
 import mat.model.clause.MeasureShareDTO;
 import mat.model.clause.ShareLevel;
 import mat.model.cql.CQLLibraryShareDTO;
-import mat.server.FeatureFlagServiceImpl;
 import mat.server.LoggedInUserUtil;
 import mat.shared.model.util.MeasureDetailsUtil;
 import org.springframework.beans.factory.InitializingBean;
@@ -32,7 +32,7 @@ public class MatContextServiceUtil implements InitializingBean {
     private static MatContextServiceUtil instance;
 
     @Autowired
-    FeatureFlagServiceImpl featureFlag;
+    FeatureFlagService featureFlag;
 
     @Override
     public void afterPropertiesSet() {
@@ -235,11 +235,11 @@ public class MatContextServiceUtil implements InitializingBean {
 
     public boolean isMeasureEditable(Measure measure) {
         featureFlagMap = featureFlag.findFeatureFlags();
-        return featureFlagMap.get(FeatureFlagConstant.FHIR_EDIT) || MeasureDetailsUtil.QDM.equals(measure.getMeasureModel());
+        return featureFlagMap.getOrDefault(FeatureFlagConstant.FHIR_EDIT, false) || MeasureDetailsUtil.QDM.equals(measure.getMeasureModel());
     }
 
     public boolean isCqlLibraryEditable(CQLLibrary cqlLibrary) {
         featureFlagMap = featureFlag.findFeatureFlags();
-        return featureFlagMap.get(FeatureFlagConstant.FHIR_EDIT) || MeasureDetailsUtil.QDM.equals(cqlLibrary.getLibraryModelType());
+        return featureFlagMap.getOrDefault(FeatureFlagConstant.FHIR_EDIT, false) || MeasureDetailsUtil.QDM.equals(cqlLibrary.getLibraryModelType());
     }
 }

--- a/src/main/resources/MAT.properties
+++ b/src/main/resources/MAT.properties
@@ -33,4 +33,5 @@ mat.qdm.default.expansion.id=Most Recent Code System Versions in VSAC
 #2FA_AUTH_CLASS=mat.server.twofactorauth.DefaultOTPValidatorForUser
 #2FA_AUTH_CLASS=mat.server.twofactorauth.vip.OTPValidatorForUser
 
+#At every 5th min
 mat.cache.expiry.time=300000

--- a/src/main/resources/MAT.properties
+++ b/src/main/resources/MAT.properties
@@ -32,3 +32,5 @@ mat.qdm.default.expansion.id=Most Recent Code System Versions in VSAC
 #MAT 2 factor authentication properties.
 #2FA_AUTH_CLASS=mat.server.twofactorauth.DefaultOTPValidatorForUser
 #2FA_AUTH_CLASS=mat.server.twofactorauth.vip.OTPValidatorForUser
+
+mat.cache.expiry.time=300000

--- a/src/test/java/mat/client/shared/CQLibraryGridToolbarTest.java
+++ b/src/test/java/mat/client/shared/CQLibraryGridToolbarTest.java
@@ -12,6 +12,9 @@ import com.google.gwtmockito.GwtMockitoTestRunner;
 import mat.model.LockedUserInfo;
 import mat.model.cql.CQLLibraryDataSetObject;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @RunWith(GwtMockitoTestRunner.class)
 public class CQLibraryGridToolbarTest {
 
@@ -202,10 +205,15 @@ public class CQLibraryGridToolbarTest {
     @Test
     public void testEditEditableLocked() {
         CQLLibraryDataSetObject selectedItem = new CQLLibraryDataSetObject();
+
+        Map<String, Boolean> featureFlagMap = new HashMap<>();
+        featureFlagMap.put("FhirEdit", true);
+
         selectedItem.setEditable(true);
         selectedItem.setLockedUserInfo(new LockedUserInfo());
         selectedItem.getLockedUserInfo().setEmailAddress("lockerby@gmail.com");
         selectedItem.setLocked(true);
+        MatContext.get().setFeatureFlags(featureFlagMap);
 
         toolbar.updateOnSelectionChanged(selectedItem);
 
@@ -218,6 +226,11 @@ public class CQLibraryGridToolbarTest {
     @Test
     public void testEditEditableNotLocked() {
         CQLLibraryDataSetObject selectedItem = new CQLLibraryDataSetObject();
+
+        Map<String, Boolean> featureFlagMap = new HashMap<>();
+        featureFlagMap.put("FhirEdit", true);
+
+        MatContext.get().setFeatureFlags(featureFlagMap);
         selectedItem.setEditable(true);
 
         toolbar.updateOnSelectionChanged(selectedItem);

--- a/src/test/java/mat/client/shared/CQLibraryGridToolbarTest.java
+++ b/src/test/java/mat/client/shared/CQLibraryGridToolbarTest.java
@@ -1,5 +1,8 @@
 package mat.client.shared;
 
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import mat.model.LockedUserInfo;
+import mat.model.cql.CQLLibraryDataSetObject;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.junit.Test;
@@ -7,10 +10,6 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-
-import com.google.gwtmockito.GwtMockitoTestRunner;
-import mat.model.LockedUserInfo;
-import mat.model.cql.CQLLibraryDataSetObject;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -194,7 +193,7 @@ public class CQLibraryGridToolbarTest {
     @Test
     public void testViewNotEditable() {
         CQLLibraryDataSetObject selectedItem = new CQLLibraryDataSetObject();
-
+        selectedItem.setFhirEditOrViewable(true);
         toolbar.updateOnSelectionChanged(selectedItem);
         Mockito.verify(toolbar.getEditOrViewButton(), Mockito.times(1)).setEnabled(Mockito.eq(true));
         Mockito.verify(toolbar.getEditOrViewButton(), Mockito.times(1)).setIcon(Mockito.eq(IconType.EYE));
@@ -213,6 +212,7 @@ public class CQLibraryGridToolbarTest {
         selectedItem.setLockedUserInfo(new LockedUserInfo());
         selectedItem.getLockedUserInfo().setEmailAddress("lockerby@gmail.com");
         selectedItem.setLocked(true);
+        selectedItem.setFhirEditOrViewable(true);
         MatContext.get().setFeatureFlags(featureFlagMap);
 
         toolbar.updateOnSelectionChanged(selectedItem);
@@ -232,6 +232,7 @@ public class CQLibraryGridToolbarTest {
 
         MatContext.get().setFeatureFlags(featureFlagMap);
         selectedItem.setEditable(true);
+        selectedItem.setFhirEditOrViewable(true);
 
         toolbar.updateOnSelectionChanged(selectedItem);
         Mockito.verify(toolbar.getEditOrViewButton(), Mockito.times(1)).setEnabled(Mockito.eq(true));

--- a/src/test/java/mat/client/shared/MeasureLibraryGridToolbarTest.java
+++ b/src/test/java/mat/client/shared/MeasureLibraryGridToolbarTest.java
@@ -231,11 +231,16 @@ public class MeasureLibraryGridToolbarTest {
     @Test
     public void testEditOnSelectedEditableAndLocked() {
         ManageMeasureSearchModel.Result item = new ManageMeasureSearchModel.Result();
+
+        Map<String, Boolean> featureFlagMap = new HashMap<>();
+        featureFlagMap.put("FhirEdit", true);
+
         item.setEditable(true);
         item.setMeasureLocked(true);
         item.setLockedUserInfo(new LockedUserInfo());
         item.getLockedUserInfo().setEmailAddress("fake@gmail.com");
         item.setIsComposite(true);
+        MatContext.get().setFeatureFlags(featureFlagMap);
 
         toolbar.updateOnSelectionChanged(Arrays.asList(item));
         Mockito.verify(toolbar.getEditOrViewButton(), Mockito.atLeastOnce()).setEnabled(Mockito.eq(false));
@@ -248,11 +253,16 @@ public class MeasureLibraryGridToolbarTest {
     @Test
     public void testEditOnSelectedEditableAndNotLocked() {
         ManageMeasureSearchModel.Result item = new ManageMeasureSearchModel.Result();
+
+        Map<String, Boolean> featureFlagMap = new HashMap<>();
+        featureFlagMap.put("FhirEdit", true);
+
         item.setEditable(true);
         item.setMeasureLocked(false);
         item.setLockedUserInfo(new LockedUserInfo());
         item.getLockedUserInfo().setEmailAddress("fake@gmail.com");
         item.setIsComposite(true);
+        MatContext.get().setFeatureFlags(featureFlagMap);
 
         toolbar.updateOnSelectionChanged(Arrays.asList(item));
         Mockito.verify(toolbar.getEditOrViewButton(), Mockito.atLeastOnce()).setEnabled(Mockito.eq(true));

--- a/src/test/java/mat/client/shared/MeasureLibraryGridToolbarTest.java
+++ b/src/test/java/mat/client/shared/MeasureLibraryGridToolbarTest.java
@@ -3,6 +3,7 @@ package mat.client.shared;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.constants.IconType;

--- a/src/test/java/mat/client/shared/MeasureLibraryGridToolbarTest.java
+++ b/src/test/java/mat/client/shared/MeasureLibraryGridToolbarTest.java
@@ -222,6 +222,7 @@ public class MeasureLibraryGridToolbarTest {
     public void testViewOnSelectedNotEditable() {
         ManageMeasureSearchModel.Result item = new ManageMeasureSearchModel.Result();
         item.setIsComposite(true);
+        item.setFhirEditOrViewable(true);
         toolbar.updateOnSelectionChanged(Arrays.asList(item));
         Mockito.verify(toolbar.getEditOrViewButton(), Mockito.atLeastOnce()).setEnabled(Mockito.eq(true));
         Mockito.verify(toolbar.getEditOrViewButton(), Mockito.atLeastOnce()).setIcon(Mockito.eq(IconType.EYE));
@@ -241,6 +242,7 @@ public class MeasureLibraryGridToolbarTest {
         item.setLockedUserInfo(new LockedUserInfo());
         item.getLockedUserInfo().setEmailAddress("fake@gmail.com");
         item.setIsComposite(true);
+        item.setFhirEditOrViewable(true);
         MatContext.get().setFeatureFlags(featureFlagMap);
 
         toolbar.updateOnSelectionChanged(Arrays.asList(item));
@@ -263,6 +265,7 @@ public class MeasureLibraryGridToolbarTest {
         item.setLockedUserInfo(new LockedUserInfo());
         item.getLockedUserInfo().setEmailAddress("fake@gmail.com");
         item.setIsComposite(true);
+        item.setFhirEditOrViewable(true);
         MatContext.get().setFeatureFlags(featureFlagMap);
 
         toolbar.updateOnSelectionChanged(Arrays.asList(item));

--- a/src/test/java/mat/server/service/impl/MatContextServiceUtilTest.java
+++ b/src/test/java/mat/server/service/impl/MatContextServiceUtilTest.java
@@ -97,6 +97,16 @@ public class MatContextServiceUtilTest {
     }
 
     @Test
+    public  void testIsMeasureEditableNullCheck() {
+        featureFlagMap.put("FhirEdit", false);
+        Mockito.when(featureFlagService.findFeatureFlags()).thenReturn(featureFlagMap);
+
+        measure.setMeasureModel("");
+
+        assertEquals(false, matContextServiceUtil.isMeasureModelEditable(measure));
+    }
+
+    @Test
     public  void testIsCqlLibraryEditable() {
         featureFlagMap.put("FhirEdit", true);
         Mockito.when(featureFlagService.findFeatureFlags()).thenReturn(featureFlagMap);
@@ -112,6 +122,16 @@ public class MatContextServiceUtilTest {
         Mockito.when(featureFlagService.findFeatureFlags()).thenReturn(featureFlagMap);
 
         cqlLibrary.setLibraryModelType("FHIR");
+
+        assertEquals(false, matContextServiceUtil.isCqlLibraryModelEditable(cqlLibrary));
+    }
+
+    @Test
+    public  void testIsCqlLibraryEditableNullCheck() {
+        featureFlagMap.put("FhirEdit", false);
+        Mockito.when(featureFlagService.findFeatureFlags()).thenReturn(featureFlagMap);
+
+        cqlLibrary.setLibraryModelType("");
 
         assertEquals(false, matContextServiceUtil.isCqlLibraryModelEditable(cqlLibrary));
     }

--- a/src/test/java/mat/server/service/impl/MatContextServiceUtilTest.java
+++ b/src/test/java/mat/server/service/impl/MatContextServiceUtilTest.java
@@ -1,6 +1,7 @@
 package mat.server.service.impl;
 
 import mat.client.featureFlag.service.FeatureFlagService;
+import mat.model.clause.CQLLibrary;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -21,6 +22,7 @@ public class MatContextServiceUtilTest {
 
     private MatContextServiceUtil util = new MatContextServiceUtil();
     private Measure measure = new Measure();
+    private CQLLibrary cqlLibrary = new CQLLibrary();
     private Map<String, Boolean> featureFlagMap = new HashMap<>();
 
     @Mock
@@ -81,7 +83,7 @@ public class MatContextServiceUtilTest {
 
         measure.setMeasureModel("QDM");
 
-        assertEquals(true, matContextServiceUtil.isMeasureEditable(measure));
+        assertEquals(true, matContextServiceUtil.isMeasureModelEditable(measure));
     }
 
     @Test
@@ -91,7 +93,7 @@ public class MatContextServiceUtilTest {
 
         measure.setMeasureModel("FHIR");
 
-        assertEquals(false, matContextServiceUtil.isMeasureEditable(measure));
+        assertEquals(false, matContextServiceUtil.isMeasureModelEditable(measure));
     }
 
     @Test
@@ -99,9 +101,9 @@ public class MatContextServiceUtilTest {
         featureFlagMap.put("FhirEdit", true);
         Mockito.when(featureFlagService.findFeatureFlags()).thenReturn(featureFlagMap);
 
-        measure.setMeasureModel("QDM");
+        cqlLibrary.setLibraryModelType("QDM");
 
-        assertEquals(true, matContextServiceUtil.isMeasureEditable(measure));
+        assertEquals(true, matContextServiceUtil.isCqlLibraryModelEditable(cqlLibrary));
     }
 
     @Test
@@ -109,8 +111,8 @@ public class MatContextServiceUtilTest {
         featureFlagMap.put("FhirEdit", false);
         Mockito.when(featureFlagService.findFeatureFlags()).thenReturn(featureFlagMap);
 
-        measure.setMeasureModel("FHIR");
+        cqlLibrary.setLibraryModelType("FHIR");
 
-        assertEquals(false, matContextServiceUtil.isMeasureEditable(measure));
+        assertEquals(false, matContextServiceUtil.isCqlLibraryModelEditable(cqlLibrary));
     }
 }

--- a/src/test/java/mat/server/service/impl/MatContextServiceUtilTest.java
+++ b/src/test/java/mat/server/service/impl/MatContextServiceUtilTest.java
@@ -1,14 +1,33 @@
 package mat.server.service.impl;
 
+import mat.client.featureFlag.service.FeatureFlagService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import mat.model.clause.Measure;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
 public class MatContextServiceUtilTest {
 
     private MatContextServiceUtil util = new MatContextServiceUtil();
     private Measure measure = new Measure();
+    private Map<String, Boolean> featureFlagMap = new HashMap<>();
+
+    @Mock
+    FeatureFlagService featureFlagService;
+
+    @InjectMocks
+    MatContextServiceUtil matContextServiceUtil;
 
     @Test
     public void testDefaultMeasureNotConvertible() {
@@ -55,4 +74,43 @@ public class MatContextServiceUtilTest {
         Assertions.assertFalse(util.isMeasureConvertible(measure));
     }
 
+    @Test
+    public  void testIsMeasureEditable() {
+        featureFlagMap.put("FhirEdit", true);
+        Mockito.when(featureFlagService.findFeatureFlags()).thenReturn(featureFlagMap);
+
+        measure.setMeasureModel("QDM");
+
+        assertEquals(true, matContextServiceUtil.isMeasureEditable(measure));
+    }
+
+    @Test
+    public  void testIsMeasureEditableFail() {
+        featureFlagMap.put("FhirEdit", false);
+        Mockito.when(featureFlagService.findFeatureFlags()).thenReturn(featureFlagMap);
+
+        measure.setMeasureModel("FHIR");
+
+        assertEquals(false, matContextServiceUtil.isMeasureEditable(measure));
+    }
+
+    @Test
+    public  void testIsCqlLibraryEditable() {
+        featureFlagMap.put("FhirEdit", true);
+        Mockito.when(featureFlagService.findFeatureFlags()).thenReturn(featureFlagMap);
+
+        measure.setMeasureModel("QDM");
+
+        assertEquals(true, matContextServiceUtil.isMeasureEditable(measure));
+    }
+
+    @Test
+    public  void testIsCqlLibraryEditableFail() {
+        featureFlagMap.put("FhirEdit", false);
+        Mockito.when(featureFlagService.findFeatureFlags()).thenReturn(featureFlagMap);
+
+        measure.setMeasureModel("FHIR");
+
+        assertEquals(false, matContextServiceUtil.isMeasureEditable(measure));
+    }
 }

--- a/src/test/java/mat/server/service/impl/MatContextServiceUtilTest.java
+++ b/src/test/java/mat/server/service/impl/MatContextServiceUtilTest.java
@@ -83,7 +83,7 @@ public class MatContextServiceUtilTest {
 
         measure.setMeasureModel("QDM");
 
-        assertEquals(true, matContextServiceUtil.isMeasureModelEditable(measure));
+        assertEquals(true, matContextServiceUtil.isMeasureModelEditable(measure.getMeasureModel()));
     }
 
     @Test
@@ -91,9 +91,9 @@ public class MatContextServiceUtilTest {
         featureFlagMap.put("FhirEdit", false);
         Mockito.when(featureFlagService.findFeatureFlags()).thenReturn(featureFlagMap);
 
-        measure.setMeasureModel("FHIR");
+        measure.setMeasureModel("QDM");
 
-        assertEquals(false, matContextServiceUtil.isMeasureModelEditable(measure));
+        assertEquals(true, matContextServiceUtil.isMeasureModelEditable(measure.getMeasureModel()));
     }
 
     @Test
@@ -103,7 +103,7 @@ public class MatContextServiceUtilTest {
 
         measure.setMeasureModel("");
 
-        assertEquals(false, matContextServiceUtil.isMeasureModelEditable(measure));
+        assertEquals(true, matContextServiceUtil.isMeasureModelEditable(measure.getMeasureModel()));
     }
 
     @Test
@@ -113,7 +113,7 @@ public class MatContextServiceUtilTest {
 
         cqlLibrary.setLibraryModelType("QDM");
 
-        assertEquals(true, matContextServiceUtil.isCqlLibraryModelEditable(cqlLibrary));
+        assertEquals(true, matContextServiceUtil.isCqlLibraryModelEditable(cqlLibrary.getLibraryModelType()));
     }
 
     @Test
@@ -121,9 +121,9 @@ public class MatContextServiceUtilTest {
         featureFlagMap.put("FhirEdit", false);
         Mockito.when(featureFlagService.findFeatureFlags()).thenReturn(featureFlagMap);
 
-        cqlLibrary.setLibraryModelType("FHIR");
+        cqlLibrary.setLibraryModelType("QDM");
 
-        assertEquals(false, matContextServiceUtil.isCqlLibraryModelEditable(cqlLibrary));
+        assertEquals(true, matContextServiceUtil.isCqlLibraryModelEditable(cqlLibrary.getLibraryModelType()));
     }
 
     @Test
@@ -133,6 +133,6 @@ public class MatContextServiceUtilTest {
 
         cqlLibrary.setLibraryModelType("");
 
-        assertEquals(false, matContextServiceUtil.isCqlLibraryModelEditable(cqlLibrary));
+        assertEquals(true, matContextServiceUtil.isCqlLibraryModelEditable(cqlLibrary.getLibraryModelType()));
     }
 }

--- a/war/WEB-INF/applicationContext-service.xml
+++ b/war/WEB-INF/applicationContext-service.xml
@@ -24,9 +24,6 @@
 	<bean id="loginService" class="mat.server.service.impl.LoginCredentialServiceImpl">	    
 	</bean>
 	
-	<bean id="featureFlag" class="mat.server.FeatureFlagServiceImpl">	    
-	</bean>
-	
     <bean id="userService" class="mat.server.service.impl.UserServiceImpl">
         <property name="accessibilityUrl" value="${mat.accessibilitypolicy.url}"/>
 	    <property name="termsOfUseUrl" value="${mat.termsofuse.url}"/>


### PR DESCRIPTION
Acceptance Criteria:

1. The FhirEdit feature flag is currently off in Dev and the sandbox environment. When we begin the edit work, the flag will be on in Dev.
2. When the flag is off, the Edit button is disabled for Fhir Measures. It is enabled for QDM measures in a draft state.
3. When the flag is off, the double click of a measure grid row does not launch the edit / view of a measure if the measure is a fhir measure but does for a QDM measure.
4. When the flag is on, the Edit button is enabled for Fhir or QDM Measures, per the edit rules. (enabled only for measures in a draft state. Enabled only for the measure owner or those whom the measure was shared with. Otherwise disabled.)
5. This impacts both measure library grids.
6. This impacts both cql grids.