### PR TITLE
Updated Model Type Display Name with new Verbiage

### DIFF
--- a/src/main/java/mat/client/CqlComposerPresenter.java
+++ b/src/main/java/mat/client/CqlComposerPresenter.java
@@ -195,7 +195,7 @@ public class CqlComposerPresenter implements MatPresenter, Enableable, TabObserv
     private static String getHeadingLibraryModel() {
         String model = "";
         if (MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.MAT_ON_FHIR)) {
-            model = " (" + MeasureDetailsUtil.defaultTypeIfBlank(MatContext.get().getCurrentLibraryInfo().getLibraryModelType()) + ")";
+            model = " (" + MeasureDetailsUtil.getModelTypeDisplayName(MatContext.get().getCurrentLibraryInfo().getLibraryModelType()) + ")";
         }
         return model;
     }

--- a/src/main/java/mat/client/MeasureComposerPresenter.java
+++ b/src/main/java/mat/client/MeasureComposerPresenter.java
@@ -286,7 +286,7 @@ public class MeasureComposerPresenter implements MatPresenter, MeasureHeading, E
     private static String getHeadingMeasureModel() {
         String model = "";
         if (MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.MAT_ON_FHIR)) {
-            model = " (" + MeasureDetailsUtil.defaultTypeIfBlank(MatContext.get().getCurrentMeasureInfo().getMeasureModel()) + ")";
+            model = " (" + MeasureDetailsUtil.getModelTypeDisplayName(MatContext.get().getCurrentMeasureInfo().getMeasureModel()) + ")";
         }
         return model;
     }

--- a/src/main/java/mat/client/cqlworkspace/CQLMeasureWorkSpacePresenter.java
+++ b/src/main/java/mat/client/cqlworkspace/CQLMeasureWorkSpacePresenter.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import mat.shared.model.util.MeasureDetailsUtil;
 import org.gwtbootstrap3.client.ui.constants.ValidationState;
 
 import com.google.gwt.core.client.GWT;
@@ -914,7 +915,7 @@ public class CQLMeasureWorkSpacePresenter extends AbstractCQLWorkspacePresenter 
 				cqlLibraryComment = result.getCqlModel().getLibraryComment();
 				String measureVersion = getCurrentMeasureVersion();
 				cqlWorkspaceView.getCqlGeneralInformationView().setGeneralInfoOfLibrary(cqlLibraryName, result.getCqlModel().getVersionUsed(),
-						result.getCqlModel().getQdmVersion(), "QDM", cqlLibraryComment);
+						result.getCqlModel().getQdmVersion(), MeasureDetailsUtil.getModelTypeDisplayName(MatContext.get().getCurrentMeasureModel()), cqlLibraryComment);
 			}
 
 			List<CQLQualityDataSetDTO> appliedValueSetAndCodeList = result.getCqlModel().getAllValueSetAndCodeList();

--- a/src/main/java/mat/client/cqlworkspace/CQLStandaloneWorkSpacePresenter.java
+++ b/src/main/java/mat/client/cqlworkspace/CQLStandaloneWorkSpacePresenter.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import mat.shared.model.util.MeasureDetailsUtil;
 import org.gwtbootstrap3.client.ui.constants.ValidationState;
 
 import com.google.gwt.core.client.GWT;
@@ -1248,7 +1249,8 @@ public class CQLStandaloneWorkSpacePresenter extends AbstractCQLWorkspacePresent
 					if (libraryVersion.startsWith("v")) {
 						libraryVersion = libraryVersion.substring(1);
 					}
-					cqlWorkspaceView.getCqlGeneralInformationView().setGeneralInfoOfLibrary(cqlLibraryName, libraryVersion, result.getCqlModel().getQdmVersion(), "QDM", cqlLibraryComment);
+					cqlWorkspaceView.getCqlGeneralInformationView().setGeneralInfoOfLibrary(cqlLibraryName, libraryVersion, result.getCqlModel().getQdmVersion(),
+							MeasureDetailsUtil.getModelTypeDisplayName(MatContext.get().getCurrentCQLLibraryModelType()), cqlLibraryComment);
 				}
 
 				List<CQLQualityDataSetDTO> appliedValueSetAndCodeList =  result.getCqlModel().getAllValueSetAndCodeList();

--- a/src/main/java/mat/client/shared/CQLLibraryResultTable.java
+++ b/src/main/java/mat/client/shared/CQLLibraryResultTable.java
@@ -74,11 +74,11 @@ public class CQLLibraryResultTable {
                 new ClickableSafeHtmlCell()) {
             @Override
             public SafeHtml getValue(CQLLibraryDataSetObject object) {
-                return CellTableUtility.getColumnToolTip(MeasureDetailsUtil.defaultTypeIfBlank(object.getLibraryModelType()));
+                return CellTableUtility.getColumnToolTip(MeasureDetailsUtil.getModelTypeDisplayName(object.getLibraryModelType()));
             }
         };
         if (MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.MAT_ON_FHIR))
-            table.addColumn(model, SafeHtmlUtils.fromSafeConstant("<span title='Version'>" + "Model" + "</span>"));
+            table.addColumn(model, SafeHtmlUtils.fromSafeConstant("<span title='Version'>" + "Models" + "</span>"));
 
         table.addCellPreviewHandler(event -> {
             String eventType = event.getNativeEvent().getType();

--- a/src/main/java/mat/client/shared/MeasureLibraryResultTable.java
+++ b/src/main/java/mat/client/shared/MeasureLibraryResultTable.java
@@ -80,11 +80,11 @@ public class MeasureLibraryResultTable {
                 new MatSafeHTMLCell()) {
             @Override
             public SafeHtml getValue(ManageMeasureSearchModel.Result object) {
-                return CellTableUtility.getColumnToolTip(MeasureDetailsUtil.defaultTypeIfBlank(object.getMeasureModel()));
+                return CellTableUtility.getColumnToolTip(MeasureDetailsUtil.getModelTypeDisplayName(object.getMeasureModel()));
             }
         };
         if (MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.MAT_ON_FHIR)) {
-            table.addColumn(model, SafeHtmlUtils.fromSafeConstant("<span title='Model'>" + "Model" + "</span>"));
+            table.addColumn(model, SafeHtmlUtils.fromSafeConstant("<span title='Model'>" + "Models" + "</span>"));
             table.setColumnWidth(model, MODEL_COLUMN_WIDTH, Style.Unit.PCT);
         }
         // Add event handler for table

--- a/src/main/java/mat/client/shared/MeasureLibraryResultTable.java
+++ b/src/main/java/mat/client/shared/MeasureLibraryResultTable.java
@@ -29,7 +29,7 @@ public class MeasureLibraryResultTable {
 
     private static final int CHECKBOX_COLUMN_WIDTH = 4;
     private static final int VERSION_COLUMN_WIDTH = 8;
-    private static final int MODEL_COLUMN_WIDTH = 10;
+    private static final int MODEL_COLUMN_WIDTH = 12;
     private static final int MOUSE_CLICK_DELAY = 300;
     private Timer singleClickTimer;
     private MultiSelectionModel<ManageMeasureSearchModel.Result> selectionModel;

--- a/src/main/java/mat/shared/model/util/MeasureDetailsUtil.java
+++ b/src/main/java/mat/shared/model/util/MeasureDetailsUtil.java
@@ -23,9 +23,9 @@ public class MeasureDetailsUtil {
     public static final String QDM = "QDM";
     public static final String PRE_CQL = "Pre-CQL";
     public static final String MAT_ON_FHIR = "MAT_ON_FHIR";
-    public static final String FHIR_CQL = "FHIR/CQL";
-    public static final String QDM_QDM = "QDM/QDM";
-    public static final String QDM_CQL = "QDM/CQL";
+    public static final String FHIR_CQL = "FHIR / CQL";
+    public static final String QDM_QDM = "QDM / QDM";
+    public static final String QDM_CQL = "QDM / CQL";
 
 
 

--- a/src/main/java/mat/shared/model/util/MeasureDetailsUtil.java
+++ b/src/main/java/mat/shared/model/util/MeasureDetailsUtil.java
@@ -23,6 +23,11 @@ public class MeasureDetailsUtil {
     public static final String QDM = "QDM";
     public static final String PRE_CQL = "Pre-CQL";
     public static final String MAT_ON_FHIR = "MAT_ON_FHIR";
+    public static final String FHIR_CQL = "FHIR/CQL";
+    public static final String QDM_QDM = "QDM/QDM";
+    public static final String QDM_CQL = "QDM/CQL";
+
+
 
     public static final BigDecimal RUN_FHIR_VALIDATION_VERSION = new BigDecimal("5.8");
     public static final BigDecimal RUN_FHIR_VALIDATION_QDM_VERSION = new BigDecimal("5.5");
@@ -108,6 +113,16 @@ public class MeasureDetailsUtil {
 
     public static boolean isQdm(String type) {
         return QDM.equalsIgnoreCase(defaultTypeIfBlank(type));
+    }
+
+    public static String getModelTypeDisplayName(String type) {
+        if (FHIR.equalsIgnoreCase(type)) {
+            return FHIR_CQL;
+        } else if (QDM.equalsIgnoreCase(type)) {
+            return QDM_CQL;
+        } else {
+            return QDM_QDM;
+        }
     }
 
     public static boolean isValidatable(Measure measure) {

--- a/src/test/java/mat/client/CqlComposerPresenterTest.java
+++ b/src/test/java/mat/client/CqlComposerPresenterTest.java
@@ -45,7 +45,7 @@ public class CqlComposerPresenterTest {
                 .build();
         MatContext.get().setCurrentLibraryInfo(selectedEvent);
         CqlComposerPresenter.setContentHeading();
-        Mockito.verify(heading, Mockito.times(1)).setHTML(Mockito.eq("<a class='invisible' name='CqlComposer'></a><h1>library1 v1 (QDM/QDM)</h1>"));
+        Mockito.verify(heading, Mockito.times(1)).setHTML(Mockito.eq("<a class='invisible' name='CqlComposer'></a><h1>library1 v1 (QDM / QDM)</h1>"));
     }
 
     @Test

--- a/src/test/java/mat/client/CqlComposerPresenterTest.java
+++ b/src/test/java/mat/client/CqlComposerPresenterTest.java
@@ -45,7 +45,7 @@ public class CqlComposerPresenterTest {
                 .build();
         MatContext.get().setCurrentLibraryInfo(selectedEvent);
         CqlComposerPresenter.setContentHeading();
-        Mockito.verify(heading, Mockito.times(1)).setHTML(Mockito.eq("<a class='invisible' name='CqlComposer'></a><h1>library1 v1 (TYPE1)</h1>"));
+        Mockito.verify(heading, Mockito.times(1)).setHTML(Mockito.eq("<a class='invisible' name='CqlComposer'></a><h1>library1 v1 (QDM/QDM)</h1>"));
     }
 
     @Test

--- a/src/test/java/mat/client/MeasureComposerPresenterTest.java
+++ b/src/test/java/mat/client/MeasureComposerPresenterTest.java
@@ -27,7 +27,7 @@ public class MeasureComposerPresenterTest {
         MatContext.get().setCurrentMeasureInfo(evt);
 
         String headingValue = MeasureComposerPresenter.buildMeasureHeading("anyId");
-        Assert.assertEquals("measure1 v1 (TYPE1)", headingValue);
+        Assert.assertEquals("measure1 v1 (QDM/QDM)", headingValue);
     }
 
     @Test

--- a/src/test/java/mat/client/MeasureComposerPresenterTest.java
+++ b/src/test/java/mat/client/MeasureComposerPresenterTest.java
@@ -27,7 +27,7 @@ public class MeasureComposerPresenterTest {
         MatContext.get().setCurrentMeasureInfo(evt);
 
         String headingValue = MeasureComposerPresenter.buildMeasureHeading("anyId");
-        Assert.assertEquals("measure1 v1 (QDM/QDM)", headingValue);
+        Assert.assertEquals("measure1 v1 (QDM / QDM)", headingValue);
     }
 
     @Test

--- a/src/test/java/mat/shared/model/util/MeasureDetailsUtilTest.java
+++ b/src/test/java/mat/shared/model/util/MeasureDetailsUtilTest.java
@@ -102,6 +102,12 @@ public class MeasureDetailsUtilTest {
     public void notReleaseVersion() {
         createMeasure();
         measure.setDraft(false);
+    }
 
+    @Test
+    public void getModelTypeDisplayNameTest() {
+        assertEquals("QDM/QDM", MeasureDetailsUtil.getModelTypeDisplayName(null));
+        assertEquals("QDM/CQL", MeasureDetailsUtil.getModelTypeDisplayName("QDM"));
+        assertEquals("FHIR/CQL", MeasureDetailsUtil.getModelTypeDisplayName("FHIR"));
     }
 }

--- a/src/test/java/mat/shared/model/util/MeasureDetailsUtilTest.java
+++ b/src/test/java/mat/shared/model/util/MeasureDetailsUtilTest.java
@@ -106,8 +106,8 @@ public class MeasureDetailsUtilTest {
 
     @Test
     public void getModelTypeDisplayNameTest() {
-        assertEquals("QDM/QDM", MeasureDetailsUtil.getModelTypeDisplayName(null));
-        assertEquals("QDM/CQL", MeasureDetailsUtil.getModelTypeDisplayName("QDM"));
-        assertEquals("FHIR/CQL", MeasureDetailsUtil.getModelTypeDisplayName("FHIR"));
+        assertEquals("QDM / QDM", MeasureDetailsUtil.getModelTypeDisplayName(null));
+        assertEquals("QDM / CQL", MeasureDetailsUtil.getModelTypeDisplayName("QDM"));
+        assertEquals("FHIR / CQL", MeasureDetailsUtil.getModelTypeDisplayName("FHIR"));
     }
 }


### PR DESCRIPTION
Acceptance Criteria:

1. Both measure library grids model columns reflect the new verbiage
2. Both CQL library grids model columns reflect the new verbiage
3. The measure CQL Workspace General Information page reflects the new verbiage
4. The CQL Composer General Information page reflects the new verbiage
5. The verbiage above the subtabs reflects the new model text
6. The column header caption is Models rather than Model
7. What currently displays as Pre-CQL will be displayed as QDM / QDM
8. What currently displays as QDM will be displayed as QDM / CQL
9. What currently displays as FHIR will be displayed as FHIR / CQL