### PR TITLE
Implemented FhirAdd Feature Flag

### DIFF
--- a/src/main/java/mat/client/measure/AbstractNewMeasureView.java
+++ b/src/main/java/mat/client/measure/AbstractNewMeasureView.java
@@ -2,6 +2,7 @@ package mat.client.measure;
 
 import java.util.List;
 
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.*;
 import mat.client.util.FeatureFlagConstant;
 import mat.shared.model.util.MeasureDetailsUtil;
@@ -257,7 +258,12 @@ public class AbstractNewMeasureView implements DetailDisplay {
 		VerticalPanel measureModelPanel = new VerticalPanel();
 		measureModelGroup.add(buildModelTypeLabel());
 		//new model creation defaulted to FHIR
-		fhirModel.setValue(true);
+		if(MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.FHIR_ADD)) {
+			fhirModel.setValue(true);
+		} else {
+			fhirModel.setEnabled(false);
+			qdmModel.setValue(true);
+		}
 		measureModelPanel.add(fhirModel);
 		measureModelPanel.add(qdmModel);
 		return measureModelPanel;

--- a/src/main/java/mat/client/measure/AbstractNewMeasureView.java
+++ b/src/main/java/mat/client/measure/AbstractNewMeasureView.java
@@ -2,7 +2,6 @@ package mat.client.measure;
 
 import java.util.List;
 
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.*;
 import mat.client.util.FeatureFlagConstant;
 import mat.shared.model.util.MeasureDetailsUtil;


### PR DESCRIPTION
Acceptance Criteria:

- The FhirAdd feature flag is currently off in Dev and the sandbox environment. When we begin the work that allows the user to add a new FHIR measure, the flag will be on in Dev.
- When the flag is off, when the user creates a new measure the model type on the Create New Measure page is set to QDM and disabled.
- When the flag is on, when the user creates a new measure the model type on the Create New Measure page is defaulted to FHIR and the user can choose either FHIR or QDM.