### PR TITLE
Feature/mat 454 cql workspace function arguments

### DIFF
--- a/src/main/java/mat/client/cqlworkspace/AbstractCQLWorkspacePresenter.java
+++ b/src/main/java/mat/client/cqlworkspace/AbstractCQLWorkspacePresenter.java
@@ -1541,7 +1541,7 @@ public abstract class AbstractCQLWorkspacePresenter {
 		resetViewCQLCollapsiblePanel(cqlWorkspaceView.getCQLFunctionsView().getPanelViewCQLCollapse());
 		cqlWorkspaceView.getCQLFunctionsView().getFunctionButtonBar().getInfoButtonGroup().getElement().setAttribute("class", "btn-group");
 		CQLFunctionArgument addNewFunctionArgument = new CQLFunctionArgument();
-		AddFunctionArgumentDialogBox.showArgumentDialogBox(addNewFunctionArgument, false,cqlWorkspaceView.getCQLFunctionsView(), messagePanel, hasEditPermissions());
+		AddFunctionArgumentDialogBox.showArgumentDialogBox(addNewFunctionArgument, false,cqlWorkspaceView.getCQLFunctionsView(), messagePanel, hasEditPermissions(), getCurrentModelType());
 		setIsPageDirty(true);
 		cqlWorkspaceView.getCQLFunctionsView().getAddNewArgument().setFocus(true);
 	}

--- a/src/main/java/mat/client/cqlworkspace/AddFunctionArgumentDialogBox.java
+++ b/src/main/java/mat/client/cqlworkspace/AddFunctionArgumentDialogBox.java
@@ -48,7 +48,7 @@ public class AddFunctionArgumentDialogBox {
 	private static ClickHandler handler;
 	
 	public static  void showArgumentDialogBox(final CQLFunctionArgument functionArg,
-			final boolean isEdit, final CQLFunctionsView cqlFunctionsView, final MessagePanel messagePanel, final boolean isEditable) {
+			final boolean isEdit, final CQLFunctionsView cqlFunctionsView, final MessagePanel messagePanel, final boolean isEditable, String currentModelType) {
 		List<String> allCqlDataType = MatContext.get().getCqlConstantContainer().getCqlKeywordList().getCqlDataTypeList();
 		final List<String> allDataTypes = MatContext.get().getCqlConstantContainer().getCqlDatatypeList();
 		final List<String> fhirDataTypes = MatContext.get().getCqlConstantContainer().getFhirCqlDataTypeList();
@@ -89,7 +89,7 @@ public class AddFunctionArgumentDialogBox {
 		listAllDataTypes.setWidth("290px");
 		listAllDataTypes.addItem(MatContext.PLEASE_SELECT);
 		for (int i = 0; i < allCqlDataType.size(); i++) {
-			if (MeasureDetailsUtil.FHIR.equalsIgnoreCase(MatContext.get().getCurrentMeasureModel()) && CQLWorkSpaceConstants.CQL_MODEL_DATA_TYPE.equalsIgnoreCase(allCqlDataType.get(i))) {
+			if (MeasureDetailsUtil.FHIR.equalsIgnoreCase(currentModelType) && CQLWorkSpaceConstants.CQL_MODEL_DATA_TYPE.equalsIgnoreCase(allCqlDataType.get(i))) {
 				listAllDataTypes.addItem(CQLWorkSpaceConstants.CQL_FHIR_DATA_TYPE);
 			} else {
 				listAllDataTypes.addItem(allCqlDataType.get(i));
@@ -138,7 +138,7 @@ public class AddFunctionArgumentDialogBox {
 
 		final FormGroup selectFormGroup = new FormGroup();
 		FormLabel selectFormLabel = new FormLabel();
-		if(MeasureDetailsUtil.FHIR.equalsIgnoreCase(MatContext.get().getCurrentMeasureModel())) {
+		if(MeasureDetailsUtil.FHIR.equalsIgnoreCase(currentModelType)) {
 			selectFormLabel.setText("Select FHIR Datatype Object");
 			selectFormLabel.setTitle("Select FHIR Datatype Object");
 		} else {

--- a/src/main/java/mat/client/cqlworkspace/AddFunctionArgumentDialogBox.java
+++ b/src/main/java/mat/client/cqlworkspace/AddFunctionArgumentDialogBox.java
@@ -1,7 +1,9 @@
 package mat.client.cqlworkspace;
 
-import java.util.List;
 
+import java.util.Collections;
+import java.util.List;
+import mat.shared.model.util.MeasureDetailsUtil;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.ButtonToolBar;
 import org.gwtbootstrap3.client.ui.FieldSet;
@@ -49,6 +51,8 @@ public class AddFunctionArgumentDialogBox {
 			final boolean isEdit, final CQLFunctionsView cqlFunctionsView, final MessagePanel messagePanel, final boolean isEditable) {
 		List<String> allCqlDataType = MatContext.get().getCqlConstantContainer().getCqlKeywordList().getCqlDataTypeList();
 		final List<String> allDataTypes = MatContext.get().getCqlConstantContainer().getCqlDatatypeList();
+		final List<String> fhirDataTypes = MatContext.get().getCqlConstantContainer().getFhirCqlDataTypeList();
+		Collections.sort(fhirDataTypes, String.CASE_INSENSITIVE_ORDER);
 		
 		final TextArea otherTypeTextArea = new TextArea();
 		otherTypeTextArea.setEnabled(false);
@@ -85,7 +89,11 @@ public class AddFunctionArgumentDialogBox {
 		listAllDataTypes.setWidth("290px");
 		listAllDataTypes.addItem(MatContext.PLEASE_SELECT);
 		for (int i = 0; i < allCqlDataType.size(); i++) {
-			listAllDataTypes.addItem(allCqlDataType.get(i));
+			if (MeasureDetailsUtil.FHIR.equalsIgnoreCase(MatContext.get().getCurrentMeasureModel()) && CQLWorkSpaceConstants.CQL_MODEL_DATA_TYPE.equalsIgnoreCase(allCqlDataType.get(i))) {
+				listAllDataTypes.addItem(CQLWorkSpaceConstants.CQL_FHIR_DATA_TYPE);
+			} else {
+				listAllDataTypes.addItem(allCqlDataType.get(i));
+			}
 		}
 
 		Form bodyForm = new Form();
@@ -130,8 +138,13 @@ public class AddFunctionArgumentDialogBox {
 
 		final FormGroup selectFormGroup = new FormGroup();
 		FormLabel selectFormLabel = new FormLabel();
-		selectFormLabel.setText("Select QDM Datatype Object");
-		selectFormLabel.setTitle("Select QDM Datatype Object");
+		if(MeasureDetailsUtil.FHIR.equalsIgnoreCase(MatContext.get().getCurrentMeasureModel())) {
+			selectFormLabel.setText("Select FHIR Datatype Object");
+			selectFormLabel.setTitle("Select FHIR Datatype Object");
+		} else {
+			selectFormLabel.setText("Select QDM Datatype Object");
+			selectFormLabel.setTitle("Select QDM Datatype Object");
+		}
 		selectFormLabel.setFor("listSelectItem");
 		selectFormLabel.setId("selectFormLabel");
 		final ListBoxMVP listSelectItem = new ListBoxMVP();
@@ -186,6 +199,17 @@ public class AddFunctionArgumentDialogBox {
 						break;
 					}
 				}
+			} else if (selectedDataType.equalsIgnoreCase(CQLWorkSpaceConstants.CQL_FHIR_DATA_TYPE)) {
+				otherTypeTextArea.setEnabled(false);
+				populateAllDataType(listSelectItem, fhirDataTypes);
+				listSelectItem.setEnabled(true);
+				for (int i = 0; i < listSelectItem.getItemCount(); i++) {
+					String itemValue = listSelectItem.getItemText(i);
+					if (itemValue.equalsIgnoreCase(functionArg.getQdmDataType())) {
+						listSelectItem.setSelectedIndex(i);
+						break;
+					}
+				}
 			} else if (selectedDataType.equalsIgnoreCase(CQLWorkSpaceConstants.CQL_OTHER_DATA_TYPE)) {
 				listSelectItem.clear();
 				listSelectItem.setEnabled(false);
@@ -211,6 +235,12 @@ public class AddFunctionArgumentDialogBox {
 					otherTypeTextArea.setEnabled(false);
 					otherTypeTextArea.clear();
 					populateAllDataType(listSelectItem, allDataTypes);
+					listSelectItem.setEnabled(true);
+					addButton.setEnabled(true);
+				} else if (listAllDataTypes.getValue().equalsIgnoreCase(CQLWorkSpaceConstants.CQL_FHIR_DATA_TYPE)) {
+					otherTypeTextArea.setEnabled(false);
+					otherTypeTextArea.clear();
+					populateAllDataType(listSelectItem, fhirDataTypes);
 					listSelectItem.setEnabled(true);
 					addButton.setEnabled(true);
 				} else if (listAllDataTypes.getValue().equalsIgnoreCase(CQLWorkSpaceConstants.CQL_OTHER_DATA_TYPE)) {

--- a/src/main/java/mat/client/cqlworkspace/CQLMeasureWorkSpacePresenter.java
+++ b/src/main/java/mat/client/cqlworkspace/CQLMeasureWorkSpacePresenter.java
@@ -160,7 +160,7 @@ public class CQLMeasureWorkSpacePresenter extends AbstractCQLWorkspacePresenter 
 				if (result.getArgumentType().equalsIgnoreCase(CQLWorkSpaceConstants.CQL_MODEL_DATA_TYPE)) {
 					getAttributesForDataType(result);
 				} else {
-					AddFunctionArgumentDialogBox.showArgumentDialogBox(result, true, cqlWorkspaceView.getCQLFunctionsView(), messagePanel, hasEditPermissions());
+					AddFunctionArgumentDialogBox.showArgumentDialogBox(result, true, cqlWorkspaceView.getCQLFunctionsView(), messagePanel, hasEditPermissions(), getCurrentModelType());
 				}
 			}
 			@Override
@@ -436,7 +436,7 @@ public class CQLMeasureWorkSpacePresenter extends AbstractCQLWorkspacePresenter 
 			@Override
 			public void onSuccess(List<QDSAttributes> result) {
 				cqlWorkspaceView.getCQLLeftNavBarPanelView().setAvailableQDSAttributeList(result);
-				AddFunctionArgumentDialogBox.showArgumentDialogBox(functionArg, true, cqlWorkspaceView.getCQLFunctionsView(), messagePanel, hasEditPermissions());
+				AddFunctionArgumentDialogBox.showArgumentDialogBox(functionArg, true, cqlWorkspaceView.getCQLFunctionsView(), messagePanel, hasEditPermissions(), getCurrentModelType());
 			}
 		});
 	}

--- a/src/main/java/mat/client/cqlworkspace/CQLStandaloneWorkSpacePresenter.java
+++ b/src/main/java/mat/client/cqlworkspace/CQLStandaloneWorkSpacePresenter.java
@@ -271,7 +271,7 @@ public class CQLStandaloneWorkSpacePresenter extends AbstractCQLWorkspacePresent
 				if (result.getArgumentType().equalsIgnoreCase(CQLWorkSpaceConstants.CQL_MODEL_DATA_TYPE)) {
 					getAttributesForDataType(result);
 				} else {
-					AddFunctionArgumentDialogBox.showArgumentDialogBox(result, true,cqlWorkspaceView.getCQLFunctionsView(), messagePanel, hasEditPermissions());
+					AddFunctionArgumentDialogBox.showArgumentDialogBox(result, true,cqlWorkspaceView.getCQLFunctionsView(), messagePanel, hasEditPermissions(), getCurrentModelType());
 				}
 			}
 
@@ -1969,7 +1969,7 @@ public class CQLStandaloneWorkSpacePresenter extends AbstractCQLWorkspacePresent
 			@Override
 			public void onSuccess(List<QDSAttributes> result) {
 				cqlWorkspaceView.getCQLLeftNavBarPanelView().setAvailableQDSAttributeList(result);
-				AddFunctionArgumentDialogBox.showArgumentDialogBox(functionArg, true,cqlWorkspaceView.getCQLFunctionsView(), messagePanel, hasEditPermissions());
+				AddFunctionArgumentDialogBox.showArgumentDialogBox(functionArg, true,cqlWorkspaceView.getCQLFunctionsView(), messagePanel, hasEditPermissions(), getCurrentModelType());
 			}
 		});
 	}

--- a/src/main/java/mat/client/shared/CQLWorkSpaceConstants.java
+++ b/src/main/java/mat/client/shared/CQLWorkSpaceConstants.java
@@ -20,6 +20,7 @@ public class CQLWorkSpaceConstants {
 			+ "cause any package groupings containing that population to be cleared on the Measure Packager.";
 	
 	public static String CQL_MODEL_DATA_TYPE ="QDM Datatype";
+	public static String CQL_FHIR_DATA_TYPE ="FHIR Datatype";
 	public static String CQL_OTHER_DATA_TYPE ="Others";
 	public static String CQL_TIMING_EXPRESSION ="Build CQL Timing Expression";
 	public static String CQL_PRIMARY_TIMING_WITHIN ="within";


### PR DESCRIPTION
Acceptance Criteria:

- The Add Argument lightbox 'Available Datatypes' dropdown reflects QDM Datatype for a QDM-CQL measure and reflects FHIR Datatype for a FHIR measure.
- The drop down label Select QDM Datatype Object is displayed for a QDM-CQL measure but the label caption is FHIR Datatype Object for FHIR measures.
- If FHIR Datatype is selected in a FHIR measure, the FHIR Datatype Object displays a list of FHIR data types. 
- If QDM Datatype is selected in a QDM-CQL measure, the QDM Datatype Object displays a list of QDM data types.