### PR TITLE
MAT-522: Automated Password and User Activity Evaluation

### DIFF
--- a/src/main/java/mat/server/service/jobs/CheckUserChangePasswordLimit.java
+++ b/src/main/java/mat/server/service/jobs/CheckUserChangePasswordLimit.java
@@ -288,8 +288,8 @@ public class CheckUserChangePasswordLimit {
 
 	/**
 	 * Method to Send 
-	 * 1.Warning Email for Warning Day Limit 45 days.
-	 * 2.Password change screen for day limit >60 days
+	 * 1.Warning Email for Warning Day Limit 35 days.
+	 * 2.Password change screen for day limit >50 days
 	 *  
 	 * @return void
 	 */
@@ -401,7 +401,7 @@ public class CheckUserChangePasswordLimit {
 			
 			lastPasswordCreatedDate = DateUtils.truncate(lastPasswordCreatedDate, Calendar.DATE);
 			logger.info("User:"+user.getFirstName()+"  :::: last Created Password Date :::::   " + lastPasswordCreatedDate);
-			//for User password equals 45 days
+			//for User password equals 35 days
 			if(passwordwarningDayLimit==passwordDayLimit){
 				
 				if(lastPasswordCreatedDate.equals(passwordDaysAgo)) {

--- a/src/main/java/mat/server/service/jobs/CheckUserLastLoginTask.java
+++ b/src/main/java/mat/server/service/jobs/CheckUserLastLoginTask.java
@@ -76,8 +76,8 @@ public class CheckUserLastLoginTask {
 	
 	/**
 	 * Method to Send 
-	 * 1.Warning Email for Warning Day Limit -90 days.
-	 * 2.Account Expiration Email for day limit -180 days and 
+	 * 1.Warning Email for Warning Day Limit -30 days.
+	 * 2.Account Expiration Email for day limit -60 days and
 	 *  then marked user termination date to disable logging into the system. 
 	 * 
 	 * @return void

--- a/src/main/resources/MAT.properties
+++ b/src/main/resources/MAT.properties
@@ -1,16 +1,16 @@
-mat.warning.dayLimit=-90
+mat.warning.dayLimit=-30
 mat.warning.email.template=/mail/mail_warning_template.ftl
 mat.warning.email.subject="Your MAT Account "
 
-mat.expiry.dayLimit=-180
+mat.expiry.dayLimit=-60
 mat.expiry.email.template=/mail/mail_expiry_template.ftl
 mat.expiry.email.subject="Your MAT Account "
 
-mat.password.warning.dayLimit=-44
+mat.password.warning.dayLimit=-34
 mat.password.warning.email.template=/mail/mail_password_change_warning_template.ftl
 mat.password.warning.email.subject="Your MAT Account "
 
-mat.password.expiry.dayLimit=-54
+mat.password.expiry.dayLimit=-44
 mat.password.expiry.email.template=/mail_password_change_expiry_template.ftl
 mat.password.expiry.email.subject="Your MAT Account "
 

--- a/src/main/resources/templates/mail/mail_expiry_template.ftl
+++ b/src/main/resources/templates/mail/mail_expiry_template.ftl
@@ -1,6 +1,6 @@
 Dear ${(content.firstname)!} ${(content.lastname)!}${(content.rolename)!},
 
-Your account has been inactive for 180 days and therefore, has been disabled. 
+Your account has been inactive for 60 days and therefore, has been disabled.
 
 To inquire about re-activating your account, please, contact the Measure Authoring Tool support desk at sb-mat-help@semanticbits.com.
 

--- a/src/main/resources/templates/mail/mail_warning_template.ftl
+++ b/src/main/resources/templates/mail/mail_warning_template.ftl
@@ -1,6 +1,6 @@
 Dear ${(content.firstname)!} ${(content.lastname)!}${(content.rolename)!},
 
-You have not signed into the Measure Authoring Tool in 90 days. In order to keep your account active, please sign in within the next 90 days. Your account will be inactivated if another 90 days pass without a successful sign-in.  
+You have not signed into the Measure Authoring Tool in 30 days. In order to keep your account active, please sign in within the next 30 days. Your account will be inactivated if another 30 days pass without a successful sign-in.
  
 If you have any questions, please contact the Measure Authoring Tool support desk at sb-mat-help@semanticbits.com.
 


### PR DESCRIPTION
https://jira.cms.gov/browse/MAT-522

- Updated password expiration day limit to 50 days with warning email occurring at 35 days.
- Updated account inactivation day limit to 60 days with warning email occurring at 30 days.
- Changed day counts in email templates and code comments.