### PR TITLE
[MAT-522] Fix hibernate lazy loading error

### DIFF
--- a/src/main/java/mat/server/service/impl/UserServiceImpl.java
+++ b/src/main/java/mat/server/service/impl/UserServiceImpl.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -845,7 +846,6 @@ public class UserServiceImpl implements UserService {
      */
     @Override
     public void addByUpdateUserPasswordHistory(User user, boolean isValidPwd) {
-        List<UserPasswordHistory> pwdHistoryList = userPasswordHistoryDAO.getPasswordHistory(user.getId());
         if (isValidPwd || !(user.getPassword().isInitial()
                 || user.getPassword().isTemporaryPassword())) {
             UserPasswordHistory passwordHistory = new UserPasswordHistory();
@@ -853,8 +853,10 @@ public class UserServiceImpl implements UserService {
             passwordHistory.setPassword(user.getPassword().getPassword());
             passwordHistory.setSalt(user.getPassword().getSalt());
             passwordHistory.setCreatedDate(user.getPassword().getCreatedDate());
+
+            List<UserPasswordHistory> pwdHistoryList = userPasswordHistoryDAO.getPasswordHistory(user.getId());
             if (pwdHistoryList.size() < PASSWORD_HISTORY_SIZE) {
-                user.getPasswordHistory().add(passwordHistory);
+                userPasswordHistoryDAO.save(passwordHistory);
             } else {
                 userPasswordHistoryDAO.addByUpdateUserPasswordHistory(user);
             }

--- a/src/main/java/mat/server/service/impl/UserServiceImpl.java
+++ b/src/main/java/mat/server/service/impl/UserServiceImpl.java
@@ -13,7 +13,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
-import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/src/main/java/mat/server/service/jobs/CheckUserChangePasswordLimit.java
+++ b/src/main/java/mat/server/service/jobs/CheckUserChangePasswordLimit.java
@@ -23,7 +23,13 @@ import org.springframework.ui.freemarker.FreeMarkerTemplateUtils;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * The Class CheckUserPasswordLimit.
@@ -79,8 +85,8 @@ public class CheckUserChangePasswordLimit {
 
     /**
      * Method to Send
-     * 1.Warning Email for Warning Day Limit 45 days.
-     * 2.Password change screen for day limit >60 days
+     * 1.Warning Email for Warning Day Limit 35 days.
+     * 2.Password change screen for day limit >45 days
      *
      * @return void
      */
@@ -193,7 +199,7 @@ public class CheckUserChangePasswordLimit {
 
             lastPasswordCreatedDate = DateUtils.truncate(lastPasswordCreatedDate, Calendar.DATE);
             logger.info("User:" + user.getFirstName() + "  :::: last Created Password Date :::::   " + lastPasswordCreatedDate);
-            //for User password equals 45 days
+            //for User password equals 35 days
             if (passwordwarningDayLimit == passwordDayLimit) {
 
                 if (lastPasswordCreatedDate.equals(passwordDaysAgo)) {
@@ -204,7 +210,7 @@ public class CheckUserChangePasswordLimit {
                 }
             }
 
-            // for User Password Greater than 60 days
+            // for User Password Greater than 45 days
             else if (passwordexpiryDayLimit == passwordDayLimit) {
 
                 if (lastPasswordCreatedDate.before((passwordDaysAgo))


### PR DESCRIPTION
Password expiration emails stopped working in MATDEV around May 2019 due to a Hibernate lazy loading error when the check attempted to save the password history preventing the check from finishing.
- Error caused by service attempting to access the password history collection from a user entity outside of a hibernate session.
- Replaced call to access collection with PasswordHistoryDAO save.

Missed some comments describing day limits in original PR, fixing them error.