### PR TITLE
[MAT-650] disable bonnie integration

### DIFF
--- a/src/main/java/liquibase/addFhirBonnieFeatureFlag.xml
+++ b/src/main/java/liquibase/addFhirBonnieFeatureFlag.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet author="mat_dev_user" id="1" context="prod">
+        <sql>
+            INSERT INTO `FEATURE_FLAGS` (FLAG_NAME, FLAG_ON)
+            VALUES ('FhirBonnie', 0);
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/java/liquibase/changelog.xml
+++ b/src/main/java/liquibase/changelog.xml
@@ -13,6 +13,7 @@
     <include file="classpath:/liquibase/addConvertedFromMeasureColumn.xml"/>
     <include file="classpath:/liquibase/addMeasureDetailsReferenceType.xml"/>
     <include file="classpath:/liquibase/addFhirDTlFeatureFlags.xml"/>
+    <include file="classpath:/liquibase/addFhirBonnieFeatureFlag.xml"/>
     <include file="classpath:/liquibase/addMeasureFhirVersionColumn.xml"/>
     <include file="classpath:/liquibase/dropConvertedFhirMeasureColumn.xml"/>
     <include file="classpath:/liquibase/addLibraryFhirVersionColumn.xml"/>

--- a/src/main/java/mat/client/export/ManageExportPresenter.java
+++ b/src/main/java/mat/client/export/ManageExportPresenter.java
@@ -9,6 +9,9 @@ import mat.client.export.measure.ManageMeasureExportView;
 import mat.client.measure.ManageMeasurePresenter;
 import mat.client.measure.ManageMeasureSearchModel;
 import mat.client.shared.MatContext;
+import mat.client.util.FeatureFlagConstant;
+
+import static mat.model.clause.ModelTypeHelper.isFhir;
 
 public class ManageExportPresenter implements MatPresenter {
 	
@@ -51,7 +54,12 @@ public class ManageExportPresenter implements MatPresenter {
 			setBonnieExportVisible(true);
 		} else {
 			setBonnieExportVisible(false);
-		}				
+		}
+
+		if (!MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.FHIR_BONNIE) &&
+				isFhir(result.getMeasureModel())) {
+			setBonnieExportVisible(false);
+		}
 	}
 	
 	private void setBonnieExportVisible(boolean isVisible) {

--- a/src/main/java/mat/client/export/ManageExportView.java
+++ b/src/main/java/mat/client/export/ManageExportView.java
@@ -7,12 +7,9 @@ import org.gwtbootstrap3.client.ui.TabContent;
 import org.gwtbootstrap3.client.ui.TabListItem;
 import org.gwtbootstrap3.client.ui.TabPane;
 
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Widget;
 
 import mat.client.measure.BaseDisplay;
-import mat.client.shared.MatContext;
 import mat.client.shared.MessageAlert;
 
 public class ManageExportView implements BaseDisplay {

--- a/src/main/java/mat/client/measurepackage/MeasurePackagePresenter.java
+++ b/src/main/java/mat/client/measurepackage/MeasurePackagePresenter.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import mat.client.util.FeatureFlagConstant;
+import mat.model.clause.ModelTypeHelper;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.Panel;
 import org.gwtbootstrap3.client.ui.constants.AlertType;
@@ -737,12 +739,23 @@ public class MeasurePackagePresenter implements MatPresenter {
         return panel;
     }
 
+
     private void displayUploadToBonnieButton(boolean isEditable) {
-        if (model.getQdmVersion() != MatContext.get().getCurrentQDMVersion()) {
-            ((Button) view.getPackageMeasureAndUploadToBonnieButton()).setVisible(false);
+        // MAT-650: Disable Bonnie integration for FHIR measures until MAT-Bonnie interface is complete.
+        if (!MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.FHIR_BONNIE) &&
+                ModelTypeHelper.isFhir(MatContext.get().getCurrentMeasureModel())) {
+            ((Button) view.getPackageMeasureAndUploadToBonnieButton()).setVisible(true);
+            ((Button) view.getPackageMeasureAndUploadToBonnieButton()).setEnabled(false);
+            return;
         }
+
+        if (!model.getQdmVersion().equals(MatContext.get().getCurrentQDMVersion())) {
+            ((Button) view.getPackageMeasureAndUploadToBonnieButton()).setVisible(false);
+            return;
+        }
+
         //only check if logged into bonnie if the page is editable
-        else if (isEditable) {
+        if (isEditable) {
             ((Button) view.getPackageMeasureAndUploadToBonnieButton()).setVisible(true);
             String matUserId = MatContext.get().getLoggedinUserId();
             MatContext.get().getBonnieService().getBonnieUserInformationForUser(matUserId, new AsyncCallback<BonnieUserInformationResult>() {

--- a/src/main/java/mat/client/util/FeatureFlagConstant.java
+++ b/src/main/java/mat/client/util/FeatureFlagConstant.java
@@ -13,4 +13,5 @@ public interface FeatureFlagConstant {
     String FHIR_VIEW = "FhirView";
     String FHIR_DELETE = "FhirDelete";
     String FHIR_DT = "FhirDT";
+    String FHIR_BONNIE = "FhirBonnie";
 }

--- a/src/main/java/mat/dao/impl/FeatureFlagDAOImpl.java
+++ b/src/main/java/mat/dao/impl/FeatureFlagDAOImpl.java
@@ -23,6 +23,6 @@ public class FeatureFlagDAOImpl extends GenericDAO<FeatureFlag, String> implemen
     @Cacheable("featureFlags")
     public List<FeatureFlag> findAllFeatureFlags() {
         final List<FeatureFlag> dataTypeList = find();
-        return CollectionUtils.isNotEmpty(dataTypeList) ? dataTypeList : Collections.EMPTY_LIST;
+        return CollectionUtils.isNotEmpty(dataTypeList) ? dataTypeList : Collections.emptyList();
     }
 }


### PR DESCRIPTION
- Added FhirBonnie feature flag. Turned off for DEV and prod.
- "Package and Upload to Bonnie" will be disabled for FHIR measures when the FhirBonnie feature flag is off.
- "Upload to Bonnie" link in the Export page is hidden for FHIR measures when the FhirBonnie feature flag is off.