### PR TITLE
MAT-506 Fixed measure search by model type.

### DIFF
--- a/src/main/java/mat/dao/clause/impl/MeasureDAOImpl.java
+++ b/src/main/java/mat/dao/clause/impl/MeasureDAOImpl.java
@@ -485,13 +485,19 @@ public class MeasureDAOImpl extends GenericDAO<Measure, String> implements Measu
 
         List<Measure> measureResultList = session.createQuery(query).getResultList();
 
-        boolean isAdvancedSearch = checkIfAdvancedSearchWasUsed(measureSearchModel);
-
-        if (!user.getSecurityRole().getId().equals("2") && !isAdvancedSearch) {
+        if (isMeasureSetSearch(user,measureSearchModel)) {
             measureResultList = getAllMeasuresInSet(measureResultList);
         }
+
         measureResultList = sortMeasureList(measureResultList);
         return measureResultList;
+    }
+
+    private boolean isMeasureSetSearch(User u,MeasureSearchModel m) {
+        boolean isAdvancedSearch = checkIfAdvancedSearchWasUsed(m);
+        return m.getModelType() == SearchModel.ModelType.ALL &&
+                !StringUtils.equals(u.getSecurityRole().getId(),"2") &&
+                !isAdvancedSearch;
     }
 
     private boolean checkIfAdvancedSearchWasUsed(MeasureSearchModel measureSearchModel) {


### PR DESCRIPTION
MAT-506 Changed the dao to only do the measure set search when ModelType is ALL.
For FHIR,QDM/CQL,QDM.QDM the family search or measure set search won't be preformed.