### PR TITLE
Limiting the creation of new composite measures to QDM

### DIFF
--- a/src/main/java/mat/client/measure/AbstractNewMeasureView.java
+++ b/src/main/java/mat/client/measure/AbstractNewMeasureView.java
@@ -278,6 +278,16 @@ public class AbstractNewMeasureView implements DetailDisplay {
         return measureModelPanel;
     }
 
+    protected VerticalPanel buildCompositeModelTypePanel() {
+        VerticalPanel measureModelPanel = new VerticalPanel();
+        measureModelGroup.add(buildModelTypeLabel());
+        fhirModel.setEnabled(false);
+        qdmModel.setValue(true);
+        measureModelPanel.add(fhirModel);
+        measureModelPanel.add(qdmModel);
+        return measureModelPanel;
+    }
+
     /**
      * Add measure model type radios to create measure view iff 'MAT_ON_FHIR' flag is on
      */
@@ -286,6 +296,11 @@ public class AbstractNewMeasureView implements DetailDisplay {
             VerticalPanel modelTypePanel = buildModelTypePanel();
             measureModelGroup.add(modelTypePanel);
         }
+    }
+
+    protected void addCompositeMeasureModelType() {
+        VerticalPanel modelTypePanel = buildCompositeModelTypePanel();
+        measureModelGroup.add(modelTypePanel);
     }
 
     protected void buildMeasureNameTextArea() {

--- a/src/main/java/mat/client/measure/AbstractNewMeasureView.java
+++ b/src/main/java/mat/client/measure/AbstractNewMeasureView.java
@@ -2,6 +2,7 @@ package mat.client.measure;
 
 import java.util.List;
 
+import mat.client.shared.VerticalFlowPanel;
 import org.gwtbootstrap3.client.ui.FieldSet;
 import org.gwtbootstrap3.client.ui.FormGroup;
 import org.gwtbootstrap3.client.ui.FormLabel;
@@ -18,7 +19,6 @@ import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.RadioButton;
 import com.google.gwt.user.client.ui.SimplePanel;
-import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 import mat.client.buttons.SaveContinueCancelButtonBar;
 import mat.client.codelist.HasListBox;
@@ -263,8 +263,8 @@ public class AbstractNewMeasureView implements DetailDisplay {
      *
      * @return measureModelPanel
      */
-    protected VerticalPanel buildModelTypePanel() {
-        VerticalPanel measureModelPanel = new VerticalPanel();
+    protected VerticalFlowPanel buildModelTypePanel() {
+        VerticalFlowPanel measureModelPanel = new VerticalFlowPanel();
         measureModelGroup.add(buildModelTypeLabel());
         //new model creation defaulted to FHIR
         if (MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.FHIR_ADD)) {
@@ -278,8 +278,8 @@ public class AbstractNewMeasureView implements DetailDisplay {
         return measureModelPanel;
     }
 
-    protected VerticalPanel buildCompositeModelTypePanel() {
-        VerticalPanel measureModelPanel = new VerticalPanel();
+    protected VerticalFlowPanel buildCompositeModelTypePanel() {
+        VerticalFlowPanel measureModelPanel = new VerticalFlowPanel();
         measureModelGroup.add(buildModelTypeLabel());
         fhirModel.setEnabled(false);
         qdmModel.setValue(true);
@@ -293,14 +293,12 @@ public class AbstractNewMeasureView implements DetailDisplay {
      */
     protected void addMeasureModelType() {
         if (MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.MAT_ON_FHIR)) {
-            VerticalPanel modelTypePanel = buildModelTypePanel();
-            measureModelGroup.add(modelTypePanel);
+            measureModelGroup.add(buildModelTypePanel());
         }
     }
 
     protected void addCompositeMeasureModelType() {
-        VerticalPanel modelTypePanel = buildCompositeModelTypePanel();
-        measureModelGroup.add(modelTypePanel);
+        measureModelGroup.add(buildCompositeModelTypePanel());
     }
 
     protected void buildMeasureNameTextArea() {

--- a/src/main/java/mat/client/measure/NewCompositeMeasureView.java
+++ b/src/main/java/mat/client/measure/NewCompositeMeasureView.java
@@ -55,7 +55,7 @@ public class NewCompositeMeasureView extends AbstractNewMeasureView {
 		measureNameGroup.add(measureNameTextBox);
 
 		//Measure mode type radios
-		addMeasureModelType();
+		addCompositeMeasureModelType();
 		
 		HorizontalPanel cqlLibraryNamePanel = buildCQLLibraryNamePanel();
 		cqlLibraryNameGroup.add(cqlLibraryNamePanel);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/57495404/76229797-25f84500-61f9-11ea-843b-7e23f41a42f2.png)

- This is not behind a feature flag. Composite FHIR measures are turned off until the standards are agreed upon.
- In the Create New Composite Measure, the Model radio button is set to QDM and is disabled.