### PR TITLE
Couldn't find includes library because of version mismatch.

### DIFF
--- a/src/main/java/mat/server/CQLUtilityClass.java
+++ b/src/main/java/mat/server/CQLUtilityClass.java
@@ -425,7 +425,7 @@ public final class CQLUtilityClass {
         if (!CollectionUtils.isEmpty(includeLibList)) {
             for (CQLIncludeLibrary includeLib : includeLibList) {
                 sb.append("include ").append(includeLib.getCqlLibraryName());
-                sb.append(VERSION).append("'").append(MeasureUtility.formatVersionTextForIncludeLibraries(includeLib.getVersion())).append("' ");
+                sb.append(VERSION).append("'").append(MeasureUtility.formatVersionText(includeLib.getVersion())).append("' ");
                 sb.append("called ").append(includeLib.getAliasName());
                 sb.append("\n");
             }

--- a/src/main/java/mat/server/util/CQLUtil.java
+++ b/src/main/java/mat/server/util/CQLUtil.java
@@ -565,7 +565,7 @@ public class CQLUtil {
 		String includeCqlXMLString = new String(cqlLibrary.getCQLByteArray());
 
 		CQLModel includeCqlModel = CQLUtilityClass.getCQLModelFromXML(includeCqlXMLString);
-		cqlLibNameMap.put(cqlIncludeLibrary.getCqlLibraryName() + "-" + MeasureUtility.formatVersionTextForIncludeLibraries(cqlIncludeLibrary.getVersion()) + "|" + cqlIncludeLibrary.getAliasName(),
+		cqlLibNameMap.put(cqlIncludeLibrary.getCqlLibraryName() + "-" + MeasureUtility.formatVersionText(cqlIncludeLibrary.getVersion()) + "|" + cqlIncludeLibrary.getAliasName(),
 				new LibHolderObject(includeCqlXMLString, cqlIncludeLibrary));
 		cqlIncludeModelMap.put(cqlIncludeLibrary, includeCqlModel);
 		return includeCqlModel;

--- a/src/main/java/mat/server/util/MeasureUtility.java
+++ b/src/main/java/mat/server/util/MeasureUtility.java
@@ -40,8 +40,19 @@ public class MeasureUtility {
     public static String formatVersionText(String version) {
         StringUtility su = new StringUtility();
         String[] versionArr = version.split("\\.");
-        String majorVersion = su.trimLeadingZeros(versionArr[0]);
-        String minorVersion = su.trimLeadingZeros(versionArr[1]);
+        String majorVersion = "";
+        String minorVersion = "";
+        String revisionNumber = "";
+        for(int i = 0; i < versionArr.length; i++) {
+            if(i == 0) {
+                majorVersion = su.trimLeadingZeros(versionArr[0]);
+            } else if(i == 1) {
+                minorVersion = su.trimLeadingZeros(versionArr[1]);
+            } else {
+                revisionNumber = su.trimLeadingZeros(versionArr[2]);
+                return majorVersion + "." + minorVersion + "." + revisionFormat.format(Integer.parseInt(revisionNumber));
+            }
+        }
         return majorVersion + "." + minorVersion;
     }
 
@@ -67,24 +78,6 @@ public class MeasureUtility {
      */
     public static String formatVersionText(String revisionNumber, String version) {
         return formatVersionText(version) + "." + revisionFormat.format(Integer.parseInt(revisionNumber));
-    }
-
-    public static String formatVersionTextForIncludeLibraries(String version) {
-        StringUtility su = new StringUtility();
-        String[] versionArr = version.split("\\.");
-        String majorVersion = "";
-        String minorVersion = "";
-        String revisionNumber = "";
-        for(int i = 0; i < versionArr.length; i++) {
-            if(i == 0) {
-                majorVersion = su.trimLeadingZeros(versionArr[0]);
-            } else if(i == 1) {
-                minorVersion = su.trimLeadingZeros(versionArr[1]);
-            } else {
-                revisionNumber = su.trimLeadingZeros(versionArr[2]);
-            }
-        }
-        return majorVersion + "." + minorVersion + "." + revisionFormat.format(Integer.parseInt("".equals(revisionNumber) ? "000" : revisionNumber));
     }
 
     /**

--- a/src/test/java/mat/server/util/MeasureUtilityTest.java
+++ b/src/test/java/mat/server/util/MeasureUtilityTest.java
@@ -14,11 +14,11 @@ public class MeasureUtilityTest {
         String version = "4.002";
         String revisionNumber = "005";
         boolean isDraft = true;
-        assertEquals(MeasureUtility.getVersionText(version, isDraft), "Draft based on v4.2");
-        assertEquals(MeasureUtility.getVersionTextWithRevisionNumber(version, revisionNumber, isDraft), "Draft v4.2.005");
-        assertEquals(MeasureUtility.formatVersionText(revisionNumber, version), "4.2.005");
-        assertEquals(MeasureUtility.formatVersionText(version + "." + revisionNumber), "4.2.005");
-        assertEquals(MeasureUtility.formatVersionText(version), "4.2");
+        assertEquals("Draft based on v4.2", MeasureUtility.getVersionText(version, isDraft));
+        assertEquals( "Draft v4.2.005", MeasureUtility.getVersionTextWithRevisionNumber(version, revisionNumber, isDraft));
+        assertEquals("4.2.005", MeasureUtility.formatVersionText(revisionNumber, version));
+        assertEquals("4.2.005", MeasureUtility.formatVersionText(version + "." + revisionNumber));
+        assertEquals("4.2", MeasureUtility.formatVersionText(version));
     }
 
     @Test
@@ -26,7 +26,7 @@ public class MeasureUtilityTest {
         String version = "4.002";
         String revisionNumber = "005";
         boolean isDraft = false;
-        assertEquals(MeasureUtility.getVersionText(version, isDraft), "v4.2");
-        assertEquals(MeasureUtility.getVersionTextWithRevisionNumber(version, revisionNumber, isDraft), "v4.2");
+        assertEquals("v4.2", MeasureUtility.getVersionText(version, isDraft));
+        assertEquals("v4.2", MeasureUtility.getVersionTextWithRevisionNumber(version, revisionNumber, isDraft));
     }
 }

--- a/src/test/java/mat/server/util/MeasureUtilityTest.java
+++ b/src/test/java/mat/server/util/MeasureUtilityTest.java
@@ -17,7 +17,8 @@ public class MeasureUtilityTest {
         assertEquals(MeasureUtility.getVersionText(version, isDraft), "Draft based on v4.2");
         assertEquals(MeasureUtility.getVersionTextWithRevisionNumber(version, revisionNumber, isDraft), "Draft v4.2.005");
         assertEquals(MeasureUtility.formatVersionText(revisionNumber, version), "4.2.005");
-        assertEquals(MeasureUtility.formatVersionTextForIncludeLibraries(version + "." + revisionNumber), "4.2.005");
+        assertEquals(MeasureUtility.formatVersionText(version + "." + revisionNumber), "4.2.005");
+        assertEquals(MeasureUtility.formatVersionText(version), "4.2");
     }
 
     @Test
@@ -28,11 +29,4 @@ public class MeasureUtilityTest {
         assertEquals(MeasureUtility.getVersionText(version, isDraft), "v4.2");
         assertEquals(MeasureUtility.getVersionTextWithRevisionNumber(version, revisionNumber, isDraft), "v4.2");
     }
-
-    @Test
-    public void testFormatVersionTextForIncludeLibraries() {
-        String version = "4.002";
-        assertEquals(MeasureUtility.formatVersionTextForIncludeLibraries(version), "4.2.000");
-    }
-
 }


### PR DESCRIPTION
Solved the actual bug raised by Chris, But because of mismatch in formatting, MAT is unable to identify actual Includes libraries with similar versions. Therefore making the formatting unique. 