### PR TITLE
[Bugfix] Fix for lazy init error when saving user password history

### DIFF
--- a/src/main/java/mat/server/service/impl/UserServiceImpl.java
+++ b/src/main/java/mat/server/service/impl/UserServiceImpl.java
@@ -1001,7 +1001,7 @@ public class UserServiceImpl implements UserService {
 			passwordHistory.setSalt(user.getPassword().getSalt());
 			passwordHistory.setCreatedDate(user.getPassword().getCreatedDate());
 			if(pwdHistoryList.size()<PASSWORD_HISTORY_SIZE){
-				user.getPasswordHistory().add(passwordHistory);
+				userPasswordHistoryDAO.save(passwordHistory);
 			} else {
 				userPasswordHistoryDAO.addByUpdateUserPasswordHistory(user);
 			}


### PR DESCRIPTION
Fixes lazy init exception that occurs when saving a user's password history from the CheckUserChangePasswordLimit service.