### PR TITLE
MAT-794 Fixing issues with function arguments and escaped quotes in cql parsing.

### DIFF
--- a/src/main/java/mat/cql/CqlStringUtils.java
+++ b/src/main/java/mat/cql/CqlStringUtils.java
@@ -1,0 +1,230 @@
+package mat.cql;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.UUID;
+
+/**
+ * This class contains methods broken out of CqlToMatXml to make it easier to test.
+ */
+public class CqlStringUtils {
+    public static final char TICK = '\'';
+    public static final char QUOTE = '"';
+
+
+    /**
+     * Validates that all the specified indexes are non-negative and they are in ascending order.
+     * This is very useful when parsing because it eliminates a lot of if/else branching code.
+     *
+     * @param indexes The indexes to check.
+     * @return Returns true if all the indexes are in ascending order non negative.
+     */
+    public static boolean areValidAscendingIndexes(int... indexes) {
+        boolean result = true;
+        int last = Integer.MAX_VALUE;
+        for (int i : indexes) {
+            if (i < 0 || (last != Integer.MAX_VALUE && i < last)) {
+                result = false;
+                break;
+            }
+            last = i;
+        }
+        return result;
+    }
+
+    /**
+     * Same as areValidAscendingIndexes(int... indexes) except this one uses ParsedResult.endIndex for the indexes.
+     *
+     * @param indexes The indexes to check.
+     * @return Returns true if all the indexes are in ascending order and non negative.
+     */
+    public static boolean areValidAscendingIndexes(ParseResult... indexes) {
+        int[] intIndexes = new int[indexes.length];
+        for (int i = 0; i < indexes.length; i++) {
+            intIndexes[i] = indexes[i].getEndIndex();
+        }
+        return areValidAscendingIndexes(intIndexes);
+    }
+
+    /**
+     * @param s The string to chomp.
+     * @return Removes 1 character from the front end and end of the string.
+     */
+    public static String chomp1(String s) {
+        return s.length() >= 2 ? s.substring(1, s.length() - 1) : s;
+    }
+
+    /**
+     * @param source     The source.
+     * @param startIndex The start index.
+     * @return nextCharBoundary with QUOTE for the boundary.
+     */
+    public static ParseResult nextQuotedString(String source,
+                                               int startIndex) {
+        return nextCharBoundary(source, QUOTE, "\\" + QUOTE, startIndex);
+    }
+
+    /**
+     * @param source     The source.
+     * @param startIndex The start index.
+     * @return nextCharBoundary with TICK for the boundary.
+     */
+    public static ParseResult nextTickedString(String source,
+                                               int startIndex) {
+        return nextCharBoundary(source, TICK, "\\" + TICK, startIndex);
+    }
+
+    /**
+     * @param source     The source.
+     * @param startIndex The start index.
+     * @return A ParseResult where the string is the contents of the next string encountered bounded by
+     * boundary and the endIndex is the endBoundary.If a quoted string can not be found then a ParseResult
+     * is returned with a null string and a -1 endIndex.
+     */
+    public static ParseResult nextCharBoundary(String source,
+                                               char boundary,
+                                               String escapeChar,
+                                               int startIndex) {
+        int start = indexOf(source, boundary, startIndex);
+        int end;
+        int parsed = start + 1;
+
+        while((end = indexOf(source, boundary, parsed)) != -1) {
+            if (escapeChar == null) {
+                break;
+            } else{
+                String candidateEscapeChar = source.substring(end - (escapeChar.length() -1),end + 1);
+                if (StringUtils.equals(candidateEscapeChar,escapeChar)) {
+                    parsed = end + 1; //Find next boundary.
+                } else {
+                    break;
+                }
+            }
+        }
+
+        return areValidAscendingIndexes(start, end) ?
+                new ParseResult(source.substring(start + 1, end), end) :
+                new ParseResult(null, -1);
+    }
+
+    /**
+     * @param source     The string to search.
+     * @param indexStart The index to start at.
+     * @return Returns a ParseResult: string=nextNonWhitespaceCharFound endIndex=indexOfNonWhitespaceCharFound.
+     */
+    public static ParseResult nextNonWhitespace(String source,
+                                                int indexStart) {
+        int index = -1;
+        char c = 0;
+
+        for (int i = indexStart; i < source.length(); i++) {
+            index = i;
+            c = source.charAt(index);
+            if (!Character.isWhitespace(c)) {
+                break;
+            }
+        }
+        return new ParseResult("" + c, index);
+    }
+
+    /**
+     * @param source     The string to search.
+     * @param indexStart The index to start at.
+     * @return Returns a ParseResult: string=nextNonWhitespaceCharFound endIndex=indexOfNonWhitespaceCharFound.
+     */
+    public static ParseResult nextCharMatching(String source,
+                                               int indexStart,
+                                               char ... matchingChars) {
+        int index = -1;
+        char c = 0;
+
+        for (int i = indexStart; i < source.length(); i++) {
+            if (contains(c = source.charAt(i),matchingChars)) {
+                index = i;
+                break;
+            }
+        }
+        return new ParseResult("" + c, index);
+    }
+
+    public static ParseResult nextCharNotMatching(String source,
+                                                  int indexStart,
+                                                  char ... notMatchingChars) {
+        int index = -1;
+        char c = 0;
+
+        for (int i = indexStart; i < source.length(); i++) {
+            if (!contains(c = source.charAt(i),notMatchingChars)) {
+                index = i;
+                break;
+            }
+        }
+        return new ParseResult("" + c, index);
+    }
+
+    /**
+     * @param c The char.
+     * @param chars The chars to check.
+     * @return Returns true if c is in chars, otherwise false.
+     */
+    public static boolean contains(char c,char[] chars) {
+        boolean result = false;
+        for (char cc : chars) {
+            if (cc == c) {
+                result = true;
+                break;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * The same as string.indexOf(search,indexStart) but this method returns
+     * -1 instead of throwing an exception if indexStart is negative.
+     * It allows for cleaner parsing code without a bunch of branching ifs.
+     *
+     * @param source     The string to index.
+     * @param search     The search string.
+     * @param indexStart The index to start at.
+     * @return The result.
+     */
+    public static int indexOf(String source,
+                              String search,
+                              int indexStart) {
+        return indexStart < 0 ? -1 : source.indexOf(search, indexStart);
+    }
+
+    /**
+     * The same as string.indexOf(search,indexStart) but this method returns
+     * -1 instead of throwing an exception if indexStart is negative.
+     * It allows for cleaner parsing code without a bunch of branching ifs.
+     *
+     * @param source     The string to index.
+     * @param search     The search string.
+     * @param indexStart The index to start at.
+     * @return The result.
+     */
+    public static int indexOf(String source,
+                              char search,
+                              int indexStart) {
+        return indexStart < 0 ? -1 : source.indexOf(search, indexStart);
+    }
+
+    /**
+     * Removes the urn:oid: from the specified code system name.
+     *
+     * @param codeSystemName The code system name.
+     * @return codeSystemName with urn:oid: removed.
+     */
+    public static String trimUrn(String codeSystemName) {
+        return StringUtils.removeStart(codeSystemName, "urn:oid:");
+    }
+
+
+    /**
+     * @return A new guid string.
+     */
+    public static String newGuid() {
+        return UUID.randomUUID().toString().toLowerCase();
+    }
+}

--- a/src/main/java/mat/cql/CqlStringUtils.java
+++ b/src/main/java/mat/cql/CqlStringUtils.java
@@ -118,9 +118,9 @@ public class CqlStringUtils {
         char c = 0;
 
         for (int i = indexStart; i < source.length(); i++) {
-            index = i;
-            c = source.charAt(index);
+            c = source.charAt(i);
             if (!Character.isWhitespace(c)) {
+                index = i;
                 break;
             }
         }

--- a/src/main/java/mat/cql/CqlToMatXml.java
+++ b/src/main/java/mat/cql/CqlToMatXml.java
@@ -379,7 +379,7 @@ public class CqlToMatXml {
         int parsed = 0;
         int argStrLen = argumentString.length();
         while (parsed < argumentString.length()) {
-            int firstSpace = indexOf(argumentString, ' ', parsed);
+            int firstSpace = indexOf(argumentString, SPACE, parsed);
             ParseResult nextNonWS = nextNonWhitespace(argumentString, firstSpace + 1);
             String argName = argumentString.substring(parsed, firstSpace);
             String qdmType;
@@ -392,7 +392,7 @@ public class CqlToMatXml {
                 qdmType = nextQuoted.getString();
                 int nextArgStart = CqlStringUtils.nextCharNotMatching(argumentString,
                         nextQuoted.getEndIndex() + 1,
-                        ' ',',').getEndIndex();
+                        SPACE,COMMA).getEndIndex();
                parsed = nextArgStart == -1 ? argumentString.length() : nextArgStart;
             } else {
                 //Case where type is not a quoted string. e.g. y List<Integer>
@@ -402,7 +402,7 @@ public class CqlToMatXml {
                 qdmType = argumentString.substring(nextNonWS.getEndIndex(), endArgName.getEndIndex());
                 int nextArgStart = CqlStringUtils.nextCharNotMatching(argumentString,
                         endArgName.getEndIndex() + 1,
-                        ' ',',').getEndIndex();
+                        SPACE,COMMA).getEndIndex();
                 parsed = nextArgStart == -1 ? argumentString.length() : nextArgStart;
             }
 

--- a/src/main/java/mat/cql/CqlToMatXml.java
+++ b/src/main/java/mat/cql/CqlToMatXml.java
@@ -72,8 +72,7 @@ public class CqlToMatXml {
     private static final String FUNCTION_TOKEN = "function";
     private static final String DEFINE_FUNCTION_TOKEN = DEFINE_TOKEN + FUNCTION_TOKEN;
 
-    private static final String WHITESPACE = "\\s";
-    private static final String QDM_VERSION = "5.5";
+    private static final String WHITESPACE_REGEX = "\\s";
 
     private String convertedCql;
     private CQLModel sourceModel;
@@ -377,7 +376,6 @@ public class CqlToMatXml {
         var result = new ArrayList<CQLFunctionArgument>();
 
         int parsed = 0;
-        int argStrLen = argumentString.length();
         while (parsed < argumentString.length()) {
             int firstSpace = indexOf(argumentString, SPACE, parsed);
             ParseResult nextNonWS = nextNonWhitespace(argumentString, firstSpace + 1);

--- a/src/main/java/mat/cql/ParseResult.java
+++ b/src/main/java/mat/cql/ParseResult.java
@@ -1,0 +1,16 @@
+package mat.cql;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class ParseResult {
+    private String string;
+    private int endIndex;
+
+    public ParseResult(String string, int endIndex) {
+        this.string = string;
+        this.endIndex = endIndex;
+    }
+}

--- a/src/test/java/mat/cql/TestCqlStringUtils.java
+++ b/src/test/java/mat/cql/TestCqlStringUtils.java
@@ -1,0 +1,132 @@
+package mat.cql;
+
+import org.junit.Test;
+
+import static mat.cql.CqlStringUtils.nextQuotedString;
+import static mat.cql.CqlStringUtils.nextTickedString;
+import static org.junit.Assert.assertEquals;
+
+public class TestCqlStringUtils {
+
+    @Test
+    public void testNextQuotedStringErrors() {
+        String myString = "no quoted string here";
+        ParseResult p = nextQuotedString(myString,0);
+        assertEquals(null,p.getString());
+        assertEquals(-1,p.getEndIndex());
+
+        myString = "no quoted string \"here";
+        p = nextQuotedString(myString,0);
+        assertEquals(null,p.getString());
+        assertEquals(-1,p.getEndIndex());
+
+        myString = "no quoted string \"here\\\"";
+        p = nextQuotedString(myString,0);
+        assertEquals(null,p.getString());
+        assertEquals(-1,p.getEndIndex());
+
+    }
+
+    @Test
+    public void testNextQuotedStringNoEscape() {
+        String myString = "kjshdfrkjshdf \"This is the string\" 23847293847234\nksjdfhsdf";
+        ParseResult p = nextQuotedString(myString,0);
+        assertEquals("This is the string",p.getString());
+        assertEquals(33,p.getEndIndex());
+        assertEquals('"',myString.charAt(p.getEndIndex()));
+
+        myString = "\"This is the string\" 23847293847234\nksjdfhsdf";
+        p = nextQuotedString(myString,0);
+        assertEquals("This is the string",p.getString());
+        assertEquals(19,p.getEndIndex());
+        assertEquals('"',myString.charAt(p.getEndIndex()));
+
+        myString = "\"This is the string\"";
+        p = nextQuotedString(myString,0);
+        assertEquals("This is the string",p.getString());
+        assertEquals(19,p.getEndIndex());
+        assertEquals('"',myString.charAt(p.getEndIndex()));
+
+        myString = "\"This is the string\n\n,\t\"";
+        p = nextQuotedString(myString,0);
+        assertEquals("This is the string\n\n,\t",p.getString());
+        assertEquals(23,p.getEndIndex());
+        assertEquals('"',myString.charAt(p.getEndIndex()));
+    }
+
+    @Test
+    public void textNextQuotedStringInnerQuotes() {
+        String myString = "kjshdfrkjshdf \"This is the \\\"INNER\\\" string\" 23847293847234\nksjdfhsdf";
+        ParseResult p = nextQuotedString(myString,0);
+        assertEquals("This is the \\\"INNER\\\" string",p.getString());
+        assertEquals(43,p.getEndIndex());
+        assertEquals('"',myString.charAt(p.getEndIndex()));
+
+        myString = "\"\\\"\\\"\"";
+        p = nextQuotedString(myString,0);
+        assertEquals("\\\"\\\"",p.getString());
+        assertEquals(5,p.getEndIndex());
+        assertEquals('"',myString.charAt(p.getEndIndex()));
+    }
+
+    @Test
+    public void testNextTickedStringErrors() {
+        String myString = "no quoted string here";
+        ParseResult p = nextTickedString(myString,0);
+        assertEquals(null,p.getString());
+        assertEquals(-1,p.getEndIndex());
+
+        myString = "no quoted string \"here";
+        p = nextTickedString(myString,0);
+        assertEquals(null,p.getString());
+        assertEquals(-1,p.getEndIndex());
+
+        myString = "no quoted string \'here";
+        p = nextTickedString(myString,0);
+        assertEquals(null,p.getString());
+        assertEquals(-1,p.getEndIndex());
+
+    }
+
+    @Test
+    public void testNextTickedStringNoEscape() {
+        String myString = "kjshdfrkjshdf 'This is the string' 23847293847234\nksjdfhsdf";
+        ParseResult p = nextTickedString(myString,0);
+        assertEquals("This is the string",p.getString());
+        assertEquals(33,p.getEndIndex());
+        assertEquals('\'',myString.charAt(p.getEndIndex()));
+
+        myString = "'This is the string' 23847293847234\nksjdfhsdf";
+        p = nextTickedString(myString,0);
+        assertEquals("This is the string",p.getString());
+        assertEquals(19,p.getEndIndex());
+        assertEquals('\'',myString.charAt(p.getEndIndex()));
+
+        myString = "'This is the string'";
+        p = nextTickedString(myString,0);
+        assertEquals("This is the string",p.getString());
+        assertEquals(19,p.getEndIndex());
+        assertEquals('\'',myString.charAt(p.getEndIndex()));
+
+        myString = "'This is the string\n\n,\t'";
+        p = nextTickedString(myString,0);
+        assertEquals("This is the string\n\n,\t",p.getString());
+        assertEquals(23,p.getEndIndex());
+        assertEquals('\'',myString.charAt(p.getEndIndex()));
+    }
+
+    @Test
+    public void textNextTickedStringInnerQuotes() {
+        String myString = "kjshdfrkjshdf 'This is the \\'INNER\\' string' 23847293847234\nksjdfhsdf";
+        ParseResult p = nextTickedString(myString,0);
+        assertEquals("This is the \\'INNER\\' string",p.getString());
+        assertEquals(43,p.getEndIndex());
+        assertEquals('\'',myString.charAt(p.getEndIndex()));
+
+        myString = "'\\'\\''";
+        p = nextTickedString(myString,0);
+        assertEquals("\\'\\'",p.getString());
+        assertEquals(5,p.getEndIndex());
+        assertEquals('\'',myString.charAt(p.getEndIndex()));
+    }
+}

--- a/src/test/java/mat/cql/TestCqlToMatXml.java
+++ b/src/test/java/mat/cql/TestCqlToMatXml.java
@@ -1,6 +1,7 @@
 package mat.cql;
 
 import lombok.extern.slf4j.Slf4j;
+import mat.model.cql.CQLFunctions;
 import mat.model.cql.CQLModel;
 import mat.server.service.impl.XMLMarshalUtil;
 import mat.server.util.XmlProcessor;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -40,5 +42,30 @@ public class TestCqlToMatXml {
         assertEquals("4.0.0", destination.getUsingModelVersion());
         //TO DO: add more asserts when I get time.
         log.debug(converter.toString());
+
+
+        List<CQLFunctions> funs = destination.getCqlFunctions();
+        CQLFunctions test1 = funs.stream().filter(f -> f.getName().equals("test1")).findFirst().get();
+        assertEquals("test1",test1.getName());
+        assertEquals("RolloutIntervalsOnce(RolloutIntervalsOnce(RolloutIntervalsOnce(RolloutIntervalsOnce(Intervals))))",test1.getLogic());
+        assertEquals(1,test1.getArgumentList().size());
+        assertEquals("Test_1",test1.getArgumentList().get(0).getArgumentName());
+        assertEquals("Test \\\" 1",test1.getArgumentList().get(0).getQdmDataType());
+
+        CQLFunctions test2 = funs.stream().filter(f -> f.getName().equals("test2")).findFirst().get();
+        assertEquals("test2",test2.getName());
+        assertEquals("RolloutIntervalsOnce(RolloutIntervalsOnce(RolloutIntervalsOnce(RolloutIntervalsOnce(Intervals))))",test2.getLogic());
+        assertEquals(1,test2.getArgumentList().size());
+        assertEquals("Test_2",test2.getArgumentList().get(0).getArgumentName());
+        assertEquals("Test , 2",test2.getArgumentList().get(0).getQdmDataType());
+
+        CQLFunctions test3 = funs.stream().filter(f -> f.getName().equals("test3")).findFirst().get();
+        assertEquals("test3",test3.getName());
+        assertEquals("RolloutIntervalsOnce(RolloutIntervalsOnce(RolloutIntervalsOnce(RolloutIntervalsOnce(Intervals))))",test3.getLogic());
+        assertEquals(2,test3.getArgumentList().size());
+        assertEquals("Test_3",test3.getArgumentList().get(0).getArgumentName());
+        assertEquals("Test ,\\\" 3",test3.getArgumentList().get(0).getQdmDataType());
+        assertEquals("Value",test3.getArgumentList().get(1).getArgumentName());
+        assertEquals("Integer",test3.getArgumentList().get(1).getQdmDataType());
     }
 }

--- a/src/test/resources/test-cql/convert-1.cql
+++ b/src/test/resources/test-cql/convert-1.cql
@@ -292,6 +292,15 @@ define function "ToDays"(Value Integer ):
   if Value is not null then Quantity { value: Value, unit: 'd' } 
     else null
 
+define function "test1"(Test_1 "Test \" 1" ):
+  RolloutIntervalsOnce(RolloutIntervalsOnce(RolloutIntervalsOnce(RolloutIntervalsOnce(Intervals))))
+
+define function "test2"(Test_2 "Test , 2" ):
+  RolloutIntervalsOnce(RolloutIntervalsOnce(RolloutIntervalsOnce(RolloutIntervalsOnce(Intervals))))
+
+define function "test3"(Test_3 "Test ,\" 3" , Value Integer ):
+  RolloutIntervalsOnce(RolloutIntervalsOnce(RolloutIntervalsOnce(RolloutIntervalsOnce(Intervals))))
+
 define function "RolloutIntervals"(Intervals List<Interval<DateTime>> ):
   RolloutIntervalsOnce(RolloutIntervalsOnce(RolloutIntervalsOnce(RolloutIntervalsOnce(Intervals))))
 


### PR DESCRIPTION
        Fixed issues when parsing function arguments that contained qdmTypes that are string literals with commas in them.
        Fixed issues handling multiple function args.
        Fixed issues where quoted string literals in cql that had escaped quotes \" would fail. e.g. "blah\"blah"
        Added support to catch escaped tics also in ticed literals. e.g. 'blah\'bhah'
        Refactored a string utils class out of CqlToMatXML so the utility methods are easy to test.
        Added test cases.