### PR TITLE
MAT-820 bug fix during create new Measure

### DIFF
--- a/src/main/java/mat/server/MeasureLibraryServiceImpl.java
+++ b/src/main/java/mat/server/MeasureLibraryServiceImpl.java
@@ -1764,6 +1764,13 @@ public class MeasureLibraryServiceImpl implements MeasureLibraryService {
                 measureSet.setId(UUID.randomUUID().toString());
                 measurePackageService.save(measureSet);
             }
+
+            if (pkg.getMeasureDetails() == null) {
+                MeasureDetails measureDetails = new MeasureDetails();
+                measureDetails.setMeasure(pkg);
+                pkg.setMeasureDetails(measureDetails);
+            }
+
             pkg.setMeasureSet(measureSet);
             setValueFromModel(model, pkg);
 


### PR DESCRIPTION
When a new measure was being created, it was causing an error in the `mat.fhir.services` micro-service as it was expecting a `measure-details` row for each `measure` record

modify the logic for the `saveNewMeasure` to ensure that it creates a corresponding row in the `measure_details` table during the creation of a new `measure`.