### PR TITLE
MAT-860 search component measure failing while creating a composite measure

### DIFF
--- a/src/main/java/mat/dao/clause/impl/MeasureDAOImpl.java
+++ b/src/main/java/mat/dao/clause/impl/MeasureDAOImpl.java
@@ -78,7 +78,7 @@ public class MeasureDAOImpl extends GenericDAO<Measure, String> implements Measu
     private static final String SECURITY_ROLE_USER = "3";
     private static final String MEASURE_MODEL = "measureModel";
     private static final String ID = "id";
-    public static final String SELECT_SHARE_LEVELS = "select m.MEASURE_SET_ID, ms.SHARE_LEVEL_ID from MEASURE_SHARE ms  inner join MEASURE m on m.ID = ms.MEASURE_ID where ms.SHARE_USER_ID = :userId and m.MEASURE_SET_ID in :measureSetIds";
+    private static final String SELECT_SHARE_LEVELS = "select m.MEASURE_SET_ID, ms.SHARE_LEVEL_ID from MEASURE_SHARE ms  inner join MEASURE m on m.ID = ms.MEASURE_ID where ms.SHARE_USER_ID = :userId and m.MEASURE_SET_ID in :measureSetIds";
 
     @Autowired
     private UserDAO userDAO;
@@ -876,6 +876,10 @@ public class MeasureDAOImpl extends GenericDAO<Measure, String> implements Measu
     @Override
     public Map<String, String> findShareLevelsForUser(String userID, Set<String> measureSetIds) {
         logger.debug("MeasureDAOImpl::findShareLevelsForUser - enter");
+        if (CollectionUtils.isEmpty(measureSetIds)) {
+            return Collections.emptyMap();
+        }
+
         final StopWatch stopWatch = new StopWatch();
         stopWatch.start();
 


### PR DESCRIPTION
When attempting to create a composite measure, in the second screen, one has to search for existing (component) measures that would need to be added to create the composite measure. Currently, the search is failing due to `measureSetIds` being null or empty while doing a native query which uses the `IN` clause.
Added a pre-condition check to the `measureSetIds` parameter to make sure it is not null or empty before executing the query.

https://jira.cms.gov/browse/MAT-860
