### PR TITLE
MAT-831 Tech spike to determine how to handle codesystems in fhir '4.0.1'

### DIFF
--- a/uml/MAT-831-get_codesystem_mappings.puml
+++ b/uml/MAT-831-get_codesystem_mappings.puml
@@ -1,0 +1,7 @@
+@startuml
+MAT -> MicroServices : getCodsystemMappings
+MicroServices -> GoogleSheets: getSpreadsheetJson
+GoogleSheets -> MicroServices
+MicroServices -> MAT
+MAT -> MAT: Cache timeout in 30 min
+@enduml

--- a/uml/MAT-831-map-codesystem-oid-to-url.puml
+++ b/uml/MAT-831-map-codesystem-oid-to-url.puml
@@ -1,0 +1,10 @@
+@startuml
+(*)  --> "Check codesystem cql uri"
+If "Is OID?" then
+--> [Yes] "Process as QDM with OID."
+else
+--> [No] "Use the cached google sheet to find the oid the uri maps to."
+--> "Process as QDM with OID."
+Endif
+-->(*)
+@enduml

--- a/uml/MAT-831-map-codesystem-url-to-oid.puml
+++ b/uml/MAT-831-map-codesystem-url-to-oid.puml
@@ -1,0 +1,10 @@
+@startuml
+(*)  --> "Check codesystem cql uri"
+If "Is OID in cached google sheet?" then
+--> [Yes] "Use the url as the uri."
+-->(*)
+else
+--> [No] "Use https://fixme.org as the uri."
+Endif
+-->(*)
+@enduml


### PR DESCRIPTION
We are using a google sheet to store the oid -> url mappings:
https://docs.google.com/spreadsheets/d/15YvJbG3LsyqqN4ZIgRd88fgScbE95eK6fUilwHRw0Z0/edit#gid=0

Rob is going to fill in the TBD OIDs. These are OIDs that can't be found in FHIR 4.0.1.

**Fetching Spreadsheet data from Mat:**
![image](https://user-images.githubusercontent.com/55844901/80378365-8c4d2b80-886a-11ea-89c5-53204ce4559d.png)

**OID(QDM) to URL(FHIR)**
![image](https://user-images.githubusercontent.com/55844901/80377552-6d01ce80-8869-11ea-80ea-c89bf4a33cf5.png)

**URL(FHIR) to OID(QDM)**
![image](https://user-images.githubusercontent.com/55844901/80377580-73904600-8869-11ea-88e3-2afbb592c917.png)
