### PR TITLE
[MAT-898] Updated logout flow to prevent Okta session retension

### DIFF
--- a/src/main/java/mat/Mat.gwt.xml
+++ b/src/main/java/mat/Mat.gwt.xml
@@ -44,5 +44,4 @@
     <source path='model'/>
     <source path='DTO'/>
 
-    <!-- <add-linker name="xsiframe" /> -->
 </module>

--- a/src/main/java/mat/client/MainLayout.java
+++ b/src/main/java/mat/client/MainLayout.java
@@ -2,6 +2,7 @@ package mat.client;
 
 import java.util.List;
 
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.FormPanel;
 import com.google.gwt.user.client.ui.Hidden;
 import org.gwtbootstrap3.client.ui.AnchorButton;
@@ -58,7 +59,7 @@ public abstract class MainLayout {
     private HorizontalPanel linksPanel = new HorizontalPanel();
     private AnchorListItem profile = new AnchorListItem("MAT Account");
     private AnchorListItem signOut = new AnchorListItem("Sign Out");
-    private FormPanel logoutForm = new FormPanel();
+    private FormPanel logoutForm = new FormPanel("logout");
 
     /**
      * hide spinner and
@@ -299,6 +300,14 @@ public abstract class MainLayout {
         return collapse;
     }
 
+    /**
+     * Call Okta logout operation to log a user out by removing their Okta browser session.
+     * Note: When making requests to the /logout endpoint, the browser (user agent)
+     * should be redirected to the endpoint. You can't use AJAX with this endpoint.
+     *
+     * This operation performs a redirect to the post_logout_redirect_uri.
+     * @param harpUrl
+     */
     protected void harpLogout(String harpUrl) {
         logoutForm.setMethod(FormPanel.METHOD_GET);
 
@@ -309,7 +318,19 @@ public abstract class MainLayout {
         token.setName("id_token_hint");
         token.setValue(MatContext.get().getIdToken());
 
+        Hidden redirect = new Hidden();
+        redirect.setName("post_logout_redirect_uri");
+        String path = Window.Location.getPath();
+        String redirectUrl = Window.Location.createUrlBuilder()
+                .setPath(path.substring(0, path.lastIndexOf('/')) + ClientConstants.HTML_LOGIN)
+                .buildString();
+        if(redirectUrl.contains("#")) {
+            redirectUrl = redirectUrl.substring(0, redirectUrl.lastIndexOf('#'));
+        }
+        redirect.setValue(redirectUrl);
+
         panel.add(token);
+        panel.add(redirect);
 
         RootPanel.get().add(logoutForm);
 

--- a/src/main/java/mat/client/Mat.java
+++ b/src/main/java/mat/client/Mat.java
@@ -172,7 +172,7 @@ public class Mat extends MainLayout implements EntryPoint, Enableable, TabObserv
         public void onFailure(Throwable throwable) {
             logger.log(Level.SEVERE, "LoginService::initSession -> onFailure: " + throwable.getMessage(), throwable);
             if (throwable.getMessage().contains("MAT_ACCOUNT_REVOKED_LOCKED")) {
-                String msg = "Harp UserName doesn't match existing MAT HARP_ID, redirecting to access support page";
+                String msg = "HARP User's access to the MAT has been revoked, redirecting to access support page";
                 logger.log(Level.SEVERE, msg);
                 MatContext.get().recordTransactionEvent(null, null, "MAT_ACCOUNT_REVOKED_LOCKED", msg, 0);
             } else if (throwable.getMessage().contains("HARP_ID_NOT_FOUND")) {
@@ -619,7 +619,7 @@ public class Mat extends MainLayout implements EntryPoint, Enableable, TabObserv
     }
 
     private void logout() {
-        logout(ClientConstants.HTML_LOGIN);
+        logout(null);
     }
 
     private void logout(String redirectTo) {
@@ -653,11 +653,18 @@ public class Mat extends MainLayout implements EntryPoint, Enableable, TabObserv
             public void onSuccess(String harpUrl) {
                 logger.log(Level.INFO, "HarpService::getHarpUrl -> onSuccess");
                 MatContext.get().getSynchronizationDelegate().setLogOffFlag();
-                MatContext.get().handleSignOut("SIGN_OUT_EVENT", null);
+                MatContext.get().handleSignOut("SIGN_OUT_EVENT", redirectTo);
                 harpLogout(harpUrl);
+                removeOktaTokens();
                 redirectToLogin();
             }
         });
+    }
+
+    private void removeOktaTokens() {
+        logger.log(Level.INFO, "removeOktaTokens");
+        Storage localStorage = Storage.getLocalStorageIfSupported();
+        localStorage.removeItem(OKTA_TOKEN_STORAGE);
     }
 
     public static void setSignedInAsName(String userFirstName, String userLastName) {

--- a/src/main/java/mat/client/Mat.java
+++ b/src/main/java/mat/client/Mat.java
@@ -5,6 +5,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -16,12 +17,14 @@ import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
+import com.google.gwt.http.client.UrlBuilder;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.json.client.JSONParser;
 import com.google.gwt.json.client.JSONValue;
 import com.google.gwt.storage.client.Storage;
 import com.google.gwt.user.client.History;
 import com.google.gwt.user.client.Timer;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.Window.ClosingEvent;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.Panel;
@@ -671,22 +674,18 @@ public class Mat extends MainLayout implements EntryPoint, Enableable, TabObserv
         MatContext.get().getHarpService().getHarpUrl(new AsyncCallback<String>() {
             @Override
             public void onFailure(Throwable throwable) {
-                removeOktaTokens();
+                MatContext.get().getSynchronizationDelegate().setLogOffFlag();
+                MatContext.get().handleSignOut("SIGN_OUT_EVENT", false);
             }
 
             @Override
             public void onSuccess(String harpUrl) {
-                harpLogout(harpUrl);
                 MatContext.get().getSynchronizationDelegate().setLogOffFlag();
-                MatContext.get().handleSignOut("SIGN_OUT_EVENT", true);
-                removeOktaTokens();
+                MatContext.get().handleSignOut("SIGN_OUT_EVENT", false);
+                harpLogout(harpUrl);
+                redirectToLogin();
             }
         });
-    }
-
-    private void removeOktaTokens() {
-        Storage localStorage = Storage.getLocalStorageIfSupported();
-        localStorage.removeItem(OKTA_TOKEN_STORAGE);
     }
 
     public static void setSignedInAsName(String userFirstName, String userLastName) {

--- a/src/main/java/mat/client/util/ClientConstants.java
+++ b/src/main/java/mat/client/util/ClientConstants.java
@@ -17,7 +17,7 @@ public class ClientConstants {
 
     public static final String EXT_LINK_UMLS = "https://utslogin.nlm.nih.gov/cas/login";
 
-    public static final String HTML_LOGIN = "/Login.html";
+    public static final String HTML_LOGIN = "/HarpLogin.html";
 
     public static final String HTML_MAT = "/Mat.html";
 

--- a/src/main/java/mat/server/Application.java
+++ b/src/main/java/mat/server/Application.java
@@ -39,7 +39,6 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
-import org.springframework.security.web.authentication.preauth.PreAuthenticatedCredentialsNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.web.client.RestTemplate;
@@ -156,8 +155,6 @@ public class Application extends WebSecurityConfigurerAdapter {
         filter.setAuthenticationManager(authentication -> {
             if (harpService().validateToken(authentication.getPrincipal().toString())) {
                 authentication.setAuthenticated(true);
-            } else {
-                throw new PreAuthenticatedCredentialsNotFoundException("test");
             }
             return authentication;
         });

--- a/src/main/java/mat/server/PreventCachingFilter.java
+++ b/src/main/java/mat/server/PreventCachingFilter.java
@@ -51,8 +51,8 @@ public class PreventCachingFilter implements Filter{
 			httpResponse.setHeader("Location", url);
 		}
 		//TODO MAT-864
-//		else if(requestURI.contains("/Mat.html") || requestURI.contains("/Bonnie.html")) {
-		else if(requestURI.contains("/Bonnie.html")) {
+		else if(requestURI.contains("/Mat.html") || requestURI.contains("/Bonnie.html")) {
+//		else if(requestURI.contains("/Bonnie.html")) {
 			logger.info("PreventCachingFilter");
 			
 			//

--- a/src/main/java/mat/server/PreventCachingFilter.java
+++ b/src/main/java/mat/server/PreventCachingFilter.java
@@ -50,9 +50,7 @@ public class PreventCachingFilter implements Filter{
 			}
 			httpResponse.setHeader("Location", url);
 		}
-		//TODO MAT-864
 		else if(requestURI.contains("/Mat.html") || requestURI.contains("/Bonnie.html")) {
-//		else if(requestURI.contains("/Bonnie.html")) {
 			logger.info("PreventCachingFilter");
 			
 			//
@@ -64,7 +62,6 @@ public class PreventCachingFilter implements Filter{
 			httpResponse.setDateHeader("Expires", 0);
 			httpResponse.setHeader("Pragma", "no-cache");
 			httpResponse.setHeader("Cache-control", "no-cache, no-store, must-revalidate");
-			//TODO MAT-864
 			if(LoggedInUserUtil.getLoggedInUser() == null) {
 				logger.info("Redirecting request for " + httpRequest.getRequestURI() + " to Login in session " + httpRequest.getSession().getId());
 				httpResponse.setStatus(302);

--- a/src/main/java/mat/server/service/impl/LoginCredentialServiceImpl.java
+++ b/src/main/java/mat/server/service/impl/LoginCredentialServiceImpl.java
@@ -529,7 +529,6 @@ public class LoginCredentialServiceImpl implements LoginCredentialService {
         logger.info("Setting authentication token::"+userDetails.getId());
         PreAuthenticatedAuthenticationToken auth =
                 new PreAuthenticatedAuthenticationToken(userDetails.getId(), accessToken, userDetails.getAuthorities());
-        auth.setAuthenticated(true);
         auth.setDetails(userDetails);
 
         SecurityContext sc = new SecurityContextImpl();

--- a/war/HarpLogin.js
+++ b/war/HarpLogin.js
@@ -42,7 +42,6 @@
    * @param token
    */
   function postToken(token) {
-    console.dir(token);
     document.getElementById("loginPost").value = token.accessToken;
     const form = document.getElementById("loginForm");
     form.action = "Mat.html";

--- a/war/Mat.html
+++ b/war/Mat.html
@@ -77,6 +77,7 @@
     <div id="timeOutWarning"></div>
     <div id="skipContent"></div>
     <div id="mainContent" class="mainContent"></div>
+    <iframe name="logout" style="border: 0"></iframe>
   </body>
   <head>
 	<meta http-equiv="PRAGMA" content="NO-CACHE" >


### PR DESCRIPTION
## [MAT-898: HARP OKTA: Logging out does not end the OKTA session](https://jira.cms.gov/browse/MAT-898)

**Issue:** The MAT Logout operations and the Okta logout API were attempting to re-direct to the login page, creating a race condition on whether or not the Okta logout would complete before being cancelled by the redirect.

**Solution:** Update the logout flow to wait to redirect until all logout operations are complete and move the Okta logout call to the end to ensure it's not being impacted.

1. Revoke Access Token.
2. Complete MAT logout operations.
3. Destroy browser Okta session by calling Otka logout endpoint.
4. Wait 1 second, then re-direct to login page.

Previously, there step 2 & 3 were swapped and there was no wait before the re-direct.