### PR TITLE
Prevent Loading bar from stalling during Account Verification

### DIFF
--- a/src/main/java/mat/client/Mat.java
+++ b/src/main/java/mat/client/Mat.java
@@ -289,7 +289,6 @@ public class Mat extends MainLayout implements EntryPoint, Enableable, TabObserv
 
     @Override
     protected void initEntryPoint() {
-        showLoadingMessage();
         MatContext.get().setCurrentModule(ConstantMessages.MAT_MODULE);
         content = getContentPanel();
         mainTabLayoutID = ConstantMessages.MAIN_TAB_LAYOUT_ID;
@@ -416,6 +415,7 @@ public class Mat extends MainLayout implements EntryPoint, Enableable, TabObserv
     }
 
     private void initPage() {
+        showLoadingMessage();
         MatContext.get().setListBoxCodeProvider(listBoxCodeProvider);
 
         // Init session with current user info.


### PR DESCRIPTION
The Loading bar was started before the HARP-MAT account link verification, causing the bar to remain in the header if the user needed to link their accounts and remain during account verification. Adjusted its timing to start after account verification.