### PR TITLE
MAT-993 Add/Edit bug fixes. 

### DIFF
--- a/src/main/java/mat/cql/CqlParser.java
+++ b/src/main/java/mat/cql/CqlParser.java
@@ -380,10 +380,6 @@ public class CqlParser {
                 // Encountered the next block so exit and set index before the newline.
                 nextStartIndex--; // Backup before newline.
                 isBreak = true;
-            } else if (nextStartIndex != startIndex && StringUtils.isBlank(curLine)) {
-                // Found double endline so block ends.
-                nextStartIndex = curLineRes.getEndIndex() == -1 ? cql.length() - 1 : curLineRes.getEndIndex() + 1;
-                isBreak = true;
             } else if (curLineRes.getEndIndex() != -1) {
                 // Still in logic.
                 nextStartIndex = nextStartIndex + curLine.length() + 1;

--- a/src/main/java/mat/server/cqlparser/CQLLinter.java
+++ b/src/main/java/mat/server/cqlparser/CQLLinter.java
@@ -126,9 +126,14 @@ public class CQLLinter extends cqlBaseListener {
 		}
 		
 		if(hasInvalidEdits) {
-			this.warningMessages.add("Changes made to the CQL library declaration, model declaration, "
-					+ "included libraries, value sets, codes, codesystems, and/or codesystem versions, can not be saved through the CQL Library Editor. "
-					+ "Please make those changes in the appropriate areas of the CQL Workspace.");
+			if (StringUtils.equals(this.config.getModelIdentifier(), "FHIR")) {
+				this.warningMessages.add("Changes made to the CQL library declaration and model declaration can not be saved through the CQL Library Editor. "
+						+ "Please make those changes in the appropriate areas of the CQL Workspace.");
+			} else{
+				this.warningMessages.add("Changes made to the CQL library declaration, model declaration, "
+						+ "included libraries, value sets, codes, codesystems, and/or codesystem versions, can not be saved through the CQL Library Editor. "
+						+ "Please make those changes in the appropriate areas of the CQL Workspace.");
+			}
 		}
 	}
 	


### PR DESCRIPTION
These issues came out of Measure Dev testing. Trying to get them in for drop 3.

- Defines can contain empty lines if they are in the middle of the logic. 
- Changed warning about what a user can modify if it's FHIR after changing cql in the editor.