### PR TITLE
[MAT-999] Make SMTP Host configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ cp ~/.m2/repository/mysql/mysql-connector-java/5.1.6/mysql-connector-java-5.1.6.
  -DQDM_QICORE_MAPPING_SERVICES_URL=https://matdev.semanticbits.com/qdm-qicore-mapping-services
  -DCQL_ELM_TRANSLATION_URL=https://matdev.semanticbits.com/cql-elm-translation
  ```
+
+#### Optional VM Arguments
+
+`-DSMTP_HOST`: The application sets `localhost` as the default SMTP host. Set this property to override the default.
  
  ### Run MAT on App Server
  Note: If MAT is to be run on an application server, the developer will need to run the build to create a .war file.

--- a/war/WEB-INF/applicationContext-mail.xml
+++ b/war/WEB-INF/applicationContext-mail.xml
@@ -10,7 +10,7 @@
 >
 	
     <bean id="mailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">
-        <property name="host" value="172.23.20.122"/>
+        <property name="host" value="${SMTP_HOST:localhost}"/>
     </bean>
     
     <!-- this is a template message that we can pre-load with default state -->


### PR DESCRIPTION
[MAT-999](https://jira.cms.gov/browse/MAT-999)

- Replaced hardcoded SMTP host with spring property that defaults to `localhost` and can be overriden by a system property named `SMTP_HOST`.