### PR TITLE
 [MAT-999] Make SMTP Host configurable --> master

### DIFF
--- a/war/WEB-INF/applicationContext-mail.xml
+++ b/war/WEB-INF/applicationContext-mail.xml
@@ -10,7 +10,7 @@
 >
 	
     <bean id="mailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">
-        <property name="host" value="localhost"/>
+        <property name="host" value="${SMTP_HOST:localhost}"/>
     </bean>
     
     <!-- this is a template message that we can pre-load with default state -->


### PR DESCRIPTION
[MAT-999](https://jira.cms.gov/browse/MAT-999)

- Replaced hardcoded SMTP host with spring property that defaults to `localhost` and can be overriden by a system property named `SMTP_HOST`.