### PR TITLE
Sign out of Okta session and redirect to Support page

### DIFF
--- a/war/js/HarpLogin.js
+++ b/war/js/HarpLogin.js
@@ -67,13 +67,10 @@
         },
         harpBaseUrl: harpBaseUrl,
         oktaTermsConditionsEndPoint: "https://www.emeasuretool.cms.gov/terms-and-conditions",
-        oktaRedirectEndPoint: "mft-signin/redirect",
-        ktaRedirectParamName: "appPageName",
         harpSignUpAppName: "HARP Registration",
         harpRecoveryAppName: "HARP Recovery",
         harpSignUpEndPoint: "register/profile-info",
         harpRecorveryEndPoint: "login/account-recovery",
-        oktaHelpEndPoint: "mft-signin/help",
         oktaTermsConditionsContent: "I agree to the Terms and Conditions",
         oktaTermsConditionsLinkContent: "Terms and Conditions",
         oktaTermsConditionsErrorContent: "Please accept the Terms and Conditions",
@@ -82,7 +79,6 @@
         harpSignUpUrl: "https://harp.qualitynet.org/register/profile-info",
         harpRecoveryContent: "Having trouble logging in?",
         harpRecoveryUrl: " https://harp.qualitynet.org/login/account-recovery",
-        oktaHelpContent: "MFT Help",
         isOktaHelpContentAvailable: false,
         allowRemeberDeviceMFA: false,
         features: {
@@ -132,6 +128,14 @@
             }).catch(function (err) {
               console.error("Error retrieving Okta token");
               console.dir(err);
+              // Sign user out of their Okta session (non-compatible with Okta Auth sdk 3.0+)
+              authClient.signOut()
+                  .then(function() {
+                    console.log("successfully logged out");
+                  })
+                  .fail(function(err) {
+                    console.dir(err);
+                  });
               reject(err);
             });
           } else {
@@ -160,7 +164,7 @@
       handleOkta(props.clientId, props.baseUrl, props.harpBaseUrl).catch(function (err) {
         console.error("Okta Error");
         console.dir(err);
-        console.log("done!");
+        window.location = "HarpSupport.html";
       });
     });
   });

--- a/war/js/HarpLogin.js
+++ b/war/js/HarpLogin.js
@@ -130,9 +130,6 @@
               console.dir(err);
               // Sign user out of their Okta session (non-compatible with Okta Auth sdk 3.0+)
               authClient.signOut()
-                  .then(function() {
-                    console.log("successfully logged out");
-                  })
                   .fail(function(err) {
                     console.dir(err);
                   });


### PR DESCRIPTION
When a user had authenticated with Okta, but did not have Application permissions, they were being presented a Login page minus the login widget.

This change will close the Okta session (to prevent redirect loops) and redirect the user to the Support page.

Removed unused properties from Okta widget config.