### PR TITLE
[MAT-1058] Use Okta's userinfo endpoint to retrieve user claims (MASTER)

### DIFF
--- a/src/main/java/mat/client/login/service/HarpService.java
+++ b/src/main/java/mat/client/login/service/HarpService.java
@@ -3,6 +3,8 @@ package mat.client.login.service;
 import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 
+import java.util.Map;
+
 @RemoteServiceRelativePath("harpService")
 public interface HarpService extends RemoteService {
 
@@ -13,6 +15,8 @@ public interface HarpService extends RemoteService {
     String getHarpBaseUrl();
 
     String getHarpClientId();
+
+    Map<String, String> getUserInfo(String accessToken);
 
     boolean validateToken(String token);
 }

--- a/src/main/java/mat/client/login/service/HarpServiceAsync.java
+++ b/src/main/java/mat/client/login/service/HarpServiceAsync.java
@@ -2,6 +2,8 @@ package mat.client.login.service;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
 
+import java.util.Map;
+
 public interface HarpServiceAsync extends AsynchronousService {
 
     void revoke(String accessToken, AsyncCallback<Boolean> async);
@@ -13,4 +15,6 @@ public interface HarpServiceAsync extends AsynchronousService {
     void getHarpClientId(AsyncCallback<String> async);
 
     void validateToken(String token, AsyncCallback<Boolean> async);
+
+    void getUserInfo(String accessToken, AsyncCallback<Map<String, String>> async);
 }

--- a/src/main/java/mat/server/HarpServiceImpl.java
+++ b/src/main/java/mat/server/HarpServiceImpl.java
@@ -86,7 +86,7 @@ public class HarpServiceImpl extends SpringRemoteServiceServlet implements HarpS
         acceptList.add(MediaType.APPLICATION_JSON);
         headers.setAccept(acceptList);
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        HttpEntity<TokenIntrospect> request = new HttpEntity<>(headers);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
         Map<String, Object> uriVariables = new HashMap<>();
         uriVariables.put("clientId", getHarpClientId());
         uriVariables.put("hint", "access_token");
@@ -131,7 +131,7 @@ public class HarpServiceImpl extends SpringRemoteServiceServlet implements HarpS
         headers.setAccept(acceptList);
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.set("Authorization", "Bearer " + accessToken);
-        HttpEntity<TokenIntrospect> request = new HttpEntity<>(headers);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
         Map<String, Object> uriVariables = new HashMap<>();
         uriVariables.put("clientId", getHarpClientId());
         ResponseEntity<UserInfo> response = null;

--- a/src/main/java/mat/server/HarpServiceImpl.java
+++ b/src/main/java/mat/server/HarpServiceImpl.java
@@ -142,10 +142,10 @@ public class HarpServiceImpl extends SpringRemoteServiceServlet implements HarpS
                     UserInfo.class,
                     uriVariables);
         } catch (RestClientResponseException e) {
-            logger.error("Error in validateToken:" + e.getMessage(), e);
+            logger.error("Error in getUserInfo:" + e.getMessage(), e);
             throw new RuntimeException(e);
         } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
-            logger.error("Error in validateToken:" + e.getMessage(), e);
+            logger.error("Error in getUserInfo:" + e.getMessage(), e);
         }
         UserInfo userinfo = response.getBody();
         Map<String, String> harpUserInfo = new HashMap<>();

--- a/src/main/java/mat/server/HarpServiceImpl.java
+++ b/src/main/java/mat/server/HarpServiceImpl.java
@@ -11,6 +11,9 @@ import java.util.Map;
 
 import javax.net.ssl.SSLContext;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import mat.shared.HarpConstants;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
@@ -33,6 +36,12 @@ import lombok.Setter;
 import lombok.ToString;
 import mat.client.login.service.HarpService;
 import mat.server.util.ServerConstants;
+
+import static mat.shared.HarpConstants.HARP_FAMILY_NAME;
+import static mat.shared.HarpConstants.HARP_FULLNAME;
+import static mat.shared.HarpConstants.HARP_GIVEN_NAME;
+import static mat.shared.HarpConstants.HARP_MIDDLE_NAME;
+import static mat.shared.HarpConstants.HARP_PRIMARY_EMAIL_ID;
 
 public class HarpServiceImpl extends SpringRemoteServiceServlet implements HarpService {
     private static final Log logger = LogFactory.getLog(HarpServiceImpl.class);
@@ -114,43 +123,40 @@ public class HarpServiceImpl extends SpringRemoteServiceServlet implements HarpS
         return ServerConstants.getHarpClientId();
     }
 
-//    private TokenIntrospect validate(String token) {
-//        return getClient()
-//                .post()
-//                .uri(uriBuilder -> uriBuilder
-//                        .path("/introspect")
-//                        .queryParam("token", token)
-//                        .queryParam("client_id", ServerConstants.getHarpClientId())
-//                        .queryParam("token_type_hint", "id_token")
-//                        .build())
-//                .accept(MediaType.APPLICATION_JSON)
-//                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-//                .retrieve()
-//                .bodyToMono(TokenIntrospect.class).block();
-//    }
-//
-//    private ClientResponse revokeToken(String token) {
-//        return getClient()
-//                .post()
-//                .uri(uriBuilder -> uriBuilder
-//                        .path("/revoke")
-//                        .queryParam("token", token)
-//                        .queryParam("client_id", getHarpClientId())
-//                        .queryParam("token_type_hint", "access_token")
-//                        .build())
-//                .accept(MediaType.APPLICATION_JSON)
-//                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-//                .exchange()
-//                .onErrorResume(e -> Mono.error(new MatException("Unable to revoke token.")))
-//                .block();
-//    }
-//
-//    private WebClient getClient() {
-//        if(isNull(harpOtkaClient)) {
-//            this.harpOtkaClient = WebClient.create(getHarpUrl());
-//        }
-//        return harpOtkaClient;
-//    }
+    @Override
+    public Map<String, String> getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        List<MediaType> acceptList = new ArrayList<>();
+        acceptList.add(MediaType.APPLICATION_JSON);
+        headers.setAccept(acceptList);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Authorization", "Bearer " + accessToken);
+        HttpEntity<TokenIntrospect> request = new HttpEntity<>(headers);
+        Map<String, Object> uriVariables = new HashMap<>();
+        uriVariables.put("clientId", getHarpClientId());
+        ResponseEntity<UserInfo> response = null;
+        try {
+            response = getRestTemplate().exchange(getHarpUrl() + "/userinfo?client_id={clientId}",
+                    HttpMethod.POST,
+                    request,
+                    UserInfo.class,
+                    uriVariables);
+        } catch (RestClientResponseException e) {
+            logger.error("Error in validateToken:" + e.getMessage(), e);
+            throw new RuntimeException(e);
+        } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
+            logger.error("Error in validateToken:" + e.getMessage(), e);
+        }
+        UserInfo userinfo = response.getBody();
+        Map<String, String> harpUserInfo = new HashMap<>();
+        harpUserInfo.put(HarpConstants.HARP_GIVEN_NAME, userinfo.getGivenName());
+        harpUserInfo.put(HarpConstants.HARP_MIDDLE_NAME, userinfo.getMiddleName());
+        harpUserInfo.put(HarpConstants.HARP_FAMILY_NAME, userinfo.getFamilyName());
+        harpUserInfo.put(HarpConstants.HARP_FULLNAME, userinfo.getName());
+        harpUserInfo.put(HarpConstants.HARP_PRIMARY_EMAIL_ID, userinfo.getEmail());
+        harpUserInfo.values().forEach(logger::debug);
+        return harpUserInfo;
+    }
 
     public RestTemplate getRestTemplate() throws KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
         TrustStrategy acceptingTrustStrategy = (X509Certificate[] chain, String authType) -> true;
@@ -182,5 +188,18 @@ public class HarpServiceImpl extends SpringRemoteServiceServlet implements HarpS
         private String username;
         private String name;
         private String email;
+    }
+
+    @Getter
+    @Setter
+    @ToString
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    static class UserInfo {
+        private String email;
+        private String familyName;
+        private String givenName;
+        private String middleName;
+        private String name;
     }
 }

--- a/src/main/java/mat/server/service/impl/LoginCredentialServiceImpl.java
+++ b/src/main/java/mat/server/service/impl/LoginCredentialServiceImpl.java
@@ -89,9 +89,8 @@ public class LoginCredentialServiceImpl implements LoginCredentialService {
     }
 
     private void updateUserDetails(Map<String, String> harpUserInfo, MatUserDetails userDetails, String sessionId) {
-        String fullName = harpUserInfo.get(HarpConstants.HARP_FULLNAME);
-        userDetails.setUsername(fullName.substring(0, fullName.indexOf(" ")));
-        userDetails.setUserLastName(fullName.substring(fullName.indexOf(" ")).trim());
+        userDetails.setUsername(harpUserInfo.get(HarpConstants.HARP_GIVEN_NAME));
+        userDetails.setUserLastName(harpUserInfo.get(HarpConstants.HARP_FAMILY_NAME));
         // Different emails at different organizatons for the same person.
 //        userDetails.setEmailAddress(harpUserInfo.get(HarpConstants.HARP_PRIMARY_EMAIL_ID));
         userDetails.setSessionId(sessionId);

--- a/src/main/java/mat/shared/HarpConstants.java
+++ b/src/main/java/mat/shared/HarpConstants.java
@@ -2,8 +2,11 @@ package mat.shared;
 
 public interface HarpConstants {
     String HARP_ID = "harpId";
-    String HARP_PRIMARY_EMAIL_ID = "harpPrimaryEmailId";
+    String HARP_GIVEN_NAME = "givenName";
+    String HARP_MIDDLE_NAME = "middleName";
+    String HARP_FAMILY_NAME = "familyName";
     String HARP_FULLNAME = "fullName";
+    String HARP_PRIMARY_EMAIL_ID = "harpPrimaryEmailId";
     String ACCESS_TOKEN = "accessToken";
 
     String OKTA_TOKEN_STORAGE = "okta-token-storage";


### PR DESCRIPTION
Use claims from userinfo Instead of relying on the id token when updating user details in MAT. The response from userinfo is easier to parse and more consistent as it is not affected by okta custom authorization server rules.

- Added new `HarpConstant`s for user's given name, middle name, and family name. (Previously, we only had easy access to the user's fullname on the ID Token).

- Added operation to HarpService to call Okta's `/userinfo` endpoint and parse the results into a HashMap with `HarpConstant`s as keys.

- Removed `Mat.java`'s parsing user details from the ID Token. Added call to `HarpService.getUserInfo`, which happens after validating the access token, since it is required, and the result is then saved to `MatContext` so the existing session flow can continue.

- Updated `LoginCredentialService.updateUserDetails` to use the Map values instead of parsing the first and last names from a single string.
