### PR TITLE
[MAT-1058] Use Okta's userinfo endpoint to retrieve user claims (develop)

### DIFF
--- a/src/main/java/mat/client/Mat.java
+++ b/src/main/java/mat/client/Mat.java
@@ -125,7 +125,7 @@ public class Mat extends MainLayout implements EntryPoint, Enableable, TabObserv
 
         @Override
         public void onFailure(final Throwable caught) {
-            logger.log(Level.SEVERE, "Error in initSession. Error message: " + caught.getMessage(), caught);
+            logger.log(Level.SEVERE, "Error in getCurrentUser. Error message: " + caught.getMessage(), caught);
             logout();
         }
 
@@ -375,7 +375,7 @@ public class Mat extends MainLayout implements EntryPoint, Enableable, TabObserv
                 @Override
                 public void onSuccess(Boolean aBoolean) {
                     logger.log(Level.INFO, "HarpService::validateToken -> onSuccess");
-                    linkHarpMatAccounts();
+                    getUserInfo(accessToken);
                 }
             });
         } else {
@@ -425,20 +425,35 @@ public class Mat extends MainLayout implements EntryPoint, Enableable, TabObserv
     private void parseOktaToken(String oktaToken) {
         JSONValue tokens = JSONParser.parseStrict(oktaToken);
         String accessToken = tokens.isObject().get("accessToken").isObject().get("accessToken").isString().stringValue();
+        String idToken = tokens.isObject().get("idToken").isObject().get("idToken").isString().stringValue();
 
-        JSONObject idTokenObj = tokens.isObject().get("idToken").isObject();
-        String idToken = idTokenObj.get("idToken").isString().stringValue();
-
-        harpUserInfo.put(HarpConstants.HARP_PRIMARY_EMAIL_ID, idTokenObj.get("claims").isObject().get("email").isString().stringValue());
-        harpUserInfo.put(HarpConstants.HARP_ID, idTokenObj.get("claims").isObject().get("preferred_username").isString().stringValue());
-        harpUserInfo.put(HarpConstants.HARP_FULLNAME, idTokenObj.get("claims").isObject().get("name").isString().stringValue());
-        harpUserInfo.put(HarpConstants.ACCESS_TOKEN, accessToken);
-
-        // Save tokens for HARP logout.
         MatContext.get().setIdToken(idToken);
         MatContext.get().setAccessToken(accessToken);
-        MatContext.get().setHarpUserInfo(harpUserInfo);
+        harpUserInfo.put(HarpConstants.ACCESS_TOKEN, accessToken);
+        harpUserInfo.put(HarpConstants.HARP_ID,
+                tokens.isObject().get("idToken").isObject().get("claims").isObject().get("preferred_username").isString().stringValue());
+    }
 
+    private void getUserInfo(String accessToken) {
+        MatContext.get().getHarpService().getUserInfo(accessToken, new AsyncCallback<Map<String, String>>() {
+            @Override
+            public void onFailure(Throwable throwable) {
+                logger.log(Level.SEVERE, "HarpService::getUserInfo -> onFailure", throwable);
+                // Invalid token
+                MatContext.get().getEventBus().fireEvent(new LogoffEvent());
+            }
+
+            @Override
+            public void onSuccess(Map<String, String> userInfo) {
+                logger.log(Level.INFO, "HarpService::getUserInfo -> onSuccess");
+
+                // Retrieve user details from Okta's userinfo endpoint.
+                harpUserInfo.putAll(userInfo);
+                MatContext.get().setHarpUserInfo(harpUserInfo);
+
+                linkHarpMatAccounts();
+            }
+        });
     }
 
     private void initPage() {

--- a/src/main/java/mat/client/login/service/HarpService.java
+++ b/src/main/java/mat/client/login/service/HarpService.java
@@ -3,6 +3,8 @@ package mat.client.login.service;
 import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 
+import java.util.Map;
+
 @RemoteServiceRelativePath("harpService")
 public interface HarpService extends RemoteService {
 
@@ -15,4 +17,6 @@ public interface HarpService extends RemoteService {
     String getHarpClientId();
 
     boolean validateToken(String token);
+
+    Map<String, String> getUserInfo(String accessToken);
 }

--- a/src/main/java/mat/client/login/service/HarpServiceAsync.java
+++ b/src/main/java/mat/client/login/service/HarpServiceAsync.java
@@ -2,6 +2,8 @@ package mat.client.login.service;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
 
+import java.util.Map;
+
 public interface HarpServiceAsync extends AsynchronousService {
 
     void revoke(String accessToken, AsyncCallback<Boolean> async);
@@ -13,4 +15,6 @@ public interface HarpServiceAsync extends AsynchronousService {
     void getHarpClientId(AsyncCallback<String> async);
 
     void validateToken(String token, AsyncCallback<Boolean> async);
+
+    void getUserInfo(String accessToken, AsyncCallback<Map<String, String>> async);
 }

--- a/src/main/java/mat/server/service/impl/LoginCredentialServiceImpl.java
+++ b/src/main/java/mat/server/service/impl/LoginCredentialServiceImpl.java
@@ -95,10 +95,8 @@ public class LoginCredentialServiceImpl implements LoginCredentialService {
     }
 
     private void updateUserDetails(Map<String, String> harpUserInfo, MatUserDetails userDetails, String sessionId) {
-        String fullName = harpUserInfo.get(HarpConstants.HARP_FULLNAME);
-        int spaceIndex = StringUtils.indexOf(fullName, ' ');
-        userDetails.setUsername(substring(fullName, 0, spaceIndex));
-        userDetails.setUserLastName(trimToEmpty(substring(fullName, spaceIndex)));
+        userDetails.setUsername(harpUserInfo.get(HarpConstants.HARP_GIVEN_NAME));
+        userDetails.setUserLastName(harpUserInfo.get(HarpConstants.HARP_FAMILY_NAME));
         // Don't override different emails at different organizations for the same person.
 //        userDetails.setEmailAddress(harpUserInfo.get(HarpConstants.HARP_PRIMARY_EMAIL_ID));
         userDetails.setSessionId(sessionId);

--- a/src/main/java/mat/shared/HarpConstants.java
+++ b/src/main/java/mat/shared/HarpConstants.java
@@ -3,6 +3,9 @@ package mat.shared;
 public interface HarpConstants {
     String HARP_ID = "harpId";
     String HARP_PRIMARY_EMAIL_ID = "harpPrimaryEmailId";
+    String HARP_GIVEN_NAME = "givenName";
+    String HARP_MIDDLE_NAME = "middleName";
+    String HARP_FAMILY_NAME = "familyName";
     String HARP_FULLNAME = "fullName";
     String ACCESS_TOKEN = "accessToken";
 


### PR DESCRIPTION
Use claims from userinfo Instead of relying on the id token when updating user details in MAT. The response from userinfo is easier to parse and more consistent as it is not affected by okta custom authorization server rules.

- Added new `HarpConstant`s for user's given name, middle name, and family name. (Previously, we only had easy access to the user's fullname on the ID Token).

- Added operation to HarpService to call Okta's `/userinfo` endpoint and parse the results into a HashMap with `HarpConstant`s as keys.

- Removed `Mat.java`'s parsing user details from the ID Token. Added call to `HarpService.getUserInfo`, which happens after validating the access token, since it is required, and the result is then saved to `MatContext` so the existing session flow can continue.

- Updated `LoginCredentialService.updateUserDetails` to use the Map values instead of parsing the first and last names from a single string.
