### PR TITLE
[MAT-1092] Removing Profile dropdown from account link page (master)

### DIFF
--- a/src/main/java/mat/client/Mat.java
+++ b/src/main/java/mat/client/Mat.java
@@ -343,7 +343,6 @@ public class Mat extends MainLayout implements EntryPoint, Enableable, TabObserv
             harpUserVerificationPresenter = new HarpUserVerificationPresenter(harpUserVerificationView);
             content.clear();
             harpUserVerificationInProgress = true;
-            buildLinksPanel();
             harpUserVerificationPresenter.go(content);
         });
 


### PR DESCRIPTION
The updated profile menu is dependent on knowing the logged in user's roles and org affiliations. This info is not available at the account linking stage, causing the profile builder to silently error and prevent the display of the account linking widget.