### PR TITLE
MAT-1289 Changed to correctly validate fhir for QDM. 

### DIFF
--- a/src/main/java/mat/client/measure/service/FhirConvertResultResponse.java
+++ b/src/main/java/mat/client/measure/service/FhirConvertResultResponse.java
@@ -8,6 +8,7 @@ public class FhirConvertResultResponse implements IsSerializable {
 
     private FhirValidationStatus validationStatus = new FhirValidationStatus();
     private String fhirMeasureId;
+    private String fhirCql;
 
     public FhirValidationStatus getValidationStatus() {
         return validationStatus;
@@ -23,5 +24,13 @@ public class FhirConvertResultResponse implements IsSerializable {
 
     public void setFhirMeasureId(String fhirMeasureId) {
         this.fhirMeasureId = fhirMeasureId;
+    }
+
+    public String getFhirCql() {
+        return fhirCql;
+    }
+
+    public void setFhirCql(String fhirCql) {
+        this.fhirCql = fhirCql;
     }
 }

--- a/src/main/java/mat/server/clause/FhirMeasureRemoteServiceImpl.java
+++ b/src/main/java/mat/server/clause/FhirMeasureRemoteServiceImpl.java
@@ -44,7 +44,10 @@ public class FhirMeasureRemoteServiceImpl extends SpringRemoteServiceServlet imp
             throw new MatException("Cannot get a granting ticket");
         }
         try {
-            return fhirMeasureService.convert(sourceMeasure, vsacTicketInformation.getTicket(), LoggedInUserUtil.getLoggedInUser());
+            return fhirMeasureService.convert(sourceMeasure,
+                    vsacTicketInformation.getTicket(),
+                    LoggedInUserUtil.getLoggedInUser(),
+                    true);
         } catch (MatException e) {
             logger.error("Error calling fhirMeasureService.convert", e);
             throw e;

--- a/src/main/java/mat/server/service/FhirMeasureService.java
+++ b/src/main/java/mat/server/service/FhirMeasureService.java
@@ -6,7 +6,12 @@ import mat.client.measure.service.FhirConvertResultResponse;
 import mat.client.shared.MatException;
 
 public interface FhirMeasureService {
-    FhirConvertResultResponse convert(ManageMeasureSearchModel.Result sourceMeasure, String vsacGrantingTicket, String loggedinUserId) throws MatException;
+    FhirConvertResultResponse convert(ManageMeasureSearchModel.Result sourceMeasure,
+                                      String vsacGrantingTicket,
+                                      String loggedinUserId,
+                                      boolean isUpdatingMatDB) throws MatException;
+
     FhirMeasurePackageResult packageMeasure(String measureId);
+
     String push(String measureId);
 }

--- a/src/test/java/mat/server/clause/FhirMeasureRemoteServiceImplTest.java
+++ b/src/test/java/mat/server/clause/FhirMeasureRemoteServiceImplTest.java
@@ -21,6 +21,8 @@ import mat.client.umls.service.VsacTicketInformation;
 import mat.server.service.FhirMeasureService;
 import mat.server.service.VSACApiService;
 
+import static org.mockito.ArgumentMatchers.eq;
+
 @ExtendWith(MockitoExtension.class)
 public class FhirMeasureRemoteServiceImplTest {
     @Mock
@@ -34,6 +36,9 @@ public class FhirMeasureRemoteServiceImplTest {
     @InjectMocks
     private FhirMeasureRemoteServiceImpl service;
 
+    private VsacTicketInformation ticketInfo;
+    private ManageMeasureSearchModel.Result searchModel = new ManageMeasureSearchModel.Result();
+
     @BeforeEach
     public void setUp() {
         ThreadLocal<HttpServletRequest> threadLocal = new ThreadLocal<>();
@@ -41,43 +46,39 @@ public class FhirMeasureRemoteServiceImplTest {
         Whitebox.setInternalState(service, "perThreadRequest", threadLocal);
         Mockito.when(httpServletRequest.getSession()).thenReturn(httpSession);
         Mockito.when(httpSession.getId()).thenReturn("sessionId");
-        VsacTicketInformation ticketInfo = new VsacTicketInformation();
+        ticketInfo = new VsacTicketInformation();
         ticketInfo.setTicket("vsacGrantingTicket");
-        Mockito.when(vsacApiService.getTicketGrantingTicket(Mockito.eq("sessionId"))).thenReturn(ticketInfo);
+        Mockito.when(vsacApiService.getTicketGrantingTicket(eq("sessionId"))).thenReturn(ticketInfo);
     }
 
     @AfterEach
     public void tearDown() {
-        Mockito.verify(vsacApiService, Mockito.times(1)).getTicketGrantingTicket(Mockito.eq("sessionId"));
+        Mockito.verify(vsacApiService, Mockito.times(1)).getTicketGrantingTicket(eq("sessionId"));
     }
 
     @Test
     public void testResult() throws MatException {
         FhirConvertResultResponse expectedResponse = new FhirConvertResultResponse();
-        Mockito.when(fhirMeasureService.convert(Mockito.any(ManageMeasureSearchModel.Result.class), Mockito.anyString(), Mockito.any())).thenReturn(expectedResponse);
-        FhirConvertResultResponse result = service.convert(new ManageMeasureSearchModel.Result());
+        Mockito.when(fhirMeasureService.convert(eq(searchModel), eq("vsacGrantingTicket"), eq("LoggedInUser"), eq(true))).thenReturn(expectedResponse);
+        FhirConvertResultResponse result = service.convert(searchModel);
         Assertions.assertNotNull(result);
-        Mockito.verify(fhirMeasureService, Mockito.times(1)).convert(Mockito.any(ManageMeasureSearchModel.Result.class), Mockito.anyString(), Mockito.any());
+        Mockito.verify(fhirMeasureService, Mockito.times(1)).convert(eq(searchModel), eq("vsacGrantingTicket"), eq("LoggedInUser"), eq(true));
     }
 
     @Test
     public void testMatException() throws MatException {
-        Mockito.when(fhirMeasureService.convert(Mockito.any(ManageMeasureSearchModel.Result.class), Mockito.anyString(), Mockito.any())).thenThrow(new MatException("Expected failure"));
-        Exception ex = Assertions.assertThrows(MatException.class, () -> {
-            service.convert(new ManageMeasureSearchModel.Result());
-        });
+        Mockito.when(fhirMeasureService.convert(eq(searchModel), eq("vsacGrantingTicket"), eq("LoggedInUser"), eq(true))).thenThrow(new MatException("Expected failure"));
+        Exception ex = Assertions.assertThrows(MatException.class, () -> service.convert(searchModel));
         Assertions.assertEquals("Expected failure", ex.getMessage());
-        Mockito.verify(fhirMeasureService, Mockito.times(1)).convert(Mockito.any(ManageMeasureSearchModel.Result.class), Mockito.anyString(), Mockito.any());
+        Mockito.verify(fhirMeasureService, Mockito.times(1)).convert(eq(searchModel), eq("vsacGrantingTicket"), eq("LoggedInUser"), eq(true));
     }
 
     @Test
     public void testMatExceptionOnOtherException() throws MatException {
-        Mockito.when(fhirMeasureService.convert(Mockito.any(ManageMeasureSearchModel.Result.class), Mockito.anyString(), Mockito.any())).thenThrow(new IllegalArgumentException("Expected failure"));
-        Exception ex = Assertions.assertThrows(MatException.class, () -> {
-            service.convert(new ManageMeasureSearchModel.Result());
-        });
+        Mockito.when(fhirMeasureService.convert(eq(searchModel), eq("vsacGrantingTicket"), eq("LoggedInUser"), eq(true))).thenThrow(new MatException("Expected failure"));
+        Exception ex = Assertions.assertThrows(MatException.class, () -> service.convert(new ManageMeasureSearchModel.Result()));
         Assertions.assertEquals("Expected failure", ex.getMessage());
-        Mockito.verify(fhirMeasureService, Mockito.times(1)).convert(Mockito.any(ManageMeasureSearchModel.Result.class), Mockito.anyString(), Mockito.any());
+        Mockito.verify(fhirMeasureService, Mockito.times(1)).convert(eq(searchModel), eq("vsacGrantingTicket"), eq("LoggedInUser"), eq(true));
     }
 
 }

--- a/src/test/java/mat/server/clause/FhirMeasureRemoteServiceImplTest.java
+++ b/src/test/java/mat/server/clause/FhirMeasureRemoteServiceImplTest.java
@@ -36,7 +36,6 @@ public class FhirMeasureRemoteServiceImplTest {
     @InjectMocks
     private FhirMeasureRemoteServiceImpl service;
 
-    private VsacTicketInformation ticketInfo;
     private ManageMeasureSearchModel.Result searchModel = new ManageMeasureSearchModel.Result();
 
     @BeforeEach
@@ -46,7 +45,7 @@ public class FhirMeasureRemoteServiceImplTest {
         Whitebox.setInternalState(service, "perThreadRequest", threadLocal);
         Mockito.when(httpServletRequest.getSession()).thenReturn(httpSession);
         Mockito.when(httpSession.getId()).thenReturn("sessionId");
-        ticketInfo = new VsacTicketInformation();
+        VsacTicketInformation ticketInfo = new VsacTicketInformation();
         ticketInfo.setTicket("vsacGrantingTicket");
         Mockito.when(vsacApiService.getTicketGrantingTicket(eq("sessionId"))).thenReturn(ticketInfo);
     }

--- a/src/test/java/mat/server/service/impl/FhirMeasureServiceImplTest.java
+++ b/src/test/java/mat/server/service/impl/FhirMeasureServiceImplTest.java
@@ -114,7 +114,7 @@ public class FhirMeasureServiceImplTest {
         String loggedinUserId = "someCurrentUser";
 
         Exception ex = assertThrows(MatException.class, () -> {
-            service.convert(sourceMeasure, loggedinUserId, "vsacGrantingTicket");
+            service.convert(sourceMeasure, loggedinUserId, "vsacGrantingTicket", true);
         });
 
         assertEquals("Measure cannot be converted to FHIR", ex.getMessage());
@@ -180,7 +180,7 @@ public class FhirMeasureServiceImplTest {
         Mockito.when(cqlParser.parse(Mockito.anyString(), any(CQLModel.class))).thenReturn(new MatXmlResponse(Collections.emptyList(), new CQLModel(), "CQL text"));
 
         service.TEST_MODE = true;
-        service.convert(sourceMeasureResult, "vsacGrantingTicket", loggedinUserId);
+        service.convert(sourceMeasureResult, "vsacGrantingTicket", loggedinUserId, true);
 
         Mockito.verify(measureDAO, Mockito.times(1)).deleteFhirMeasuresBySetId(Mockito.eq(setId));
     }
@@ -214,7 +214,7 @@ public class FhirMeasureServiceImplTest {
         sourceMeasure.setId(sourceMeasureId);
 
         assertThrows(MatException.class, () -> {
-            service.convert(sourceMeasureResult, "vsacGrantingTicket", loggedinUserId);
+            service.convert(sourceMeasureResult, "vsacGrantingTicket", loggedinUserId, true);
         });
 
         Mockito.verify(measureDAO, Mockito.never()).deleteFhirMeasuresBySetId(Mockito.anyString());
@@ -253,7 +253,7 @@ public class FhirMeasureServiceImplTest {
         doThrow(MatRuntimeException.class).when(measureLibraryService).recordRecentMeasureActivity(any(), any());
 
         assertThrows(MatRuntimeException.class, () -> {
-            service.convert(sourceMeasureResult, "vsacGrantingTicket", loggedinUserId);
+            service.convert(sourceMeasureResult, "vsacGrantingTicket", loggedinUserId, true);
         });
 
         Mockito.verify(measureDAO, Mockito.never()).delete(any(Measure.class));

--- a/src/test/java/tools/GenerateCommonFhirLibSql.java
+++ b/src/test/java/tools/GenerateCommonFhirLibSql.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.UUID;
 
 public class GenerateCommonFhirLibSql {
-    private static final String DB_URL = "jdbc:mysql://localhost:3306/MAT_APP_BLANK?serverTimezone=UTC&characterEncoding=latin1&useConfigs=maxPerformance";
+    private static final String DB_URL = "jdbc:mysql://localhost:3306/local-prd-sbx-dump?serverTimezone=UTC&characterEncoding=latin1&useConfigs=maxPerformance";
     private static final String DB_USER = "root";
     private static final String DB_P = "password";
 


### PR DESCRIPTION
A conversion is performed without updating mat DB and then validation is run on the CQL returned.