### PR TITLE
BUGFIX 508 Fix for JAWS to hopefully read error messages.

### DIFF
--- a/src/main/java/mat/client/measure/AbstractNewMeasureView.java
+++ b/src/main/java/mat/client/measure/AbstractNewMeasureView.java
@@ -300,7 +300,6 @@ public class AbstractNewMeasureView implements DetailDisplay {
 
     protected void buildMeasureNameTextArea() {
         measureNameTextBox.setId("MeasureNameTextArea");
-        measureNameTextBox.setTitle("Enter Measure Name Required.");
         measureNameTextBox.setWidth("400px");
         measureNameTextBox.setHeight("50px");
         measureNameTextBox.setMaxLength(500);
@@ -333,7 +332,6 @@ public class AbstractNewMeasureView implements DetailDisplay {
 
     private void buildCQLLibraryTextArea() {
         cqlLibraryNameTextBox.setId("CqlLibraryNameTextArea");
-        cqlLibraryNameTextBox.setTitle("Enter CQL Library Name Required.");
         cqlLibraryNameTextBox.setWidth("400px");
         cqlLibraryNameTextBox.setHeight("50px");
         cqlLibraryNameTextBox.setMaxLength(500);
@@ -373,7 +371,6 @@ public class AbstractNewMeasureView implements DetailDisplay {
 
     protected void buildShortNameTextBox() {
         eCQMAbbreviatedTitleTextBox.setId("ShortNameTextBox");
-        eCQMAbbreviatedTitleTextBox.setTitle("Enter eCQM Abbreviated Title Required");
         eCQMAbbreviatedTitleTextBox.setWidth("18em");
         eCQMAbbreviatedTitleTextBox.setMaxLength(32);
         eCQMAbbreviatedTitleTextBox.addBlurHandler(errorHandler.buildBlurHandler(eCQMAbbreviatedTitleTextBox,
@@ -392,7 +389,6 @@ public class AbstractNewMeasureView implements DetailDisplay {
 
     protected void buildMeasureScoringInput() {
         measureScoringListBox.getElement().setId("measScoringInput_ListBoxMVP");
-        measureScoringListBox.setTitle("Measure Scoring Required.");
         measureScoringListBox.setStyleName("form-control");
         measureScoringListBox.setVisibleItemCount(1);
         measureScoringListBox.setWidth("18em");
@@ -419,7 +415,6 @@ public class AbstractNewMeasureView implements DetailDisplay {
 
     protected void buildPatientBasedInput() {
         patientBasedListBox.getElement().setId("patientBasedMeasure_listbox");
-        patientBasedListBox.setTitle("Patient Based Indicator Required.");
         patientBasedListBox.setStyleName("form-control");
         patientBasedListBox.setVisibleItemCount(1);
         patientBasedListBox.setWidth("18em");

--- a/src/main/java/mat/client/validator/ErrorHandler.java
+++ b/src/main/java/mat/client/validator/ErrorHandler.java
@@ -63,6 +63,7 @@ public class ErrorHandler {
             null;
 
     private final Map<Element, ValidationInfo> validations;
+    private Random random = new Random();
 
     public ErrorHandler() {
         validations = new HashMap<>();
@@ -143,6 +144,8 @@ public class ErrorHandler {
         while (isErrorMessage(elementToAddErrorsAfter.getNextSiblingElement())) {
             elementToAddErrorsAfter.getNextSiblingElement().removeFromParent();
         }
+        validatedElement.removeAttribute("aria-invalid");
+        validatedElement.removeAttribute("aria-describedBy");
     }
 
     public void handleErrors(Element validatedElement, Element elementToAddErrorsAfter, List<String> errors) {
@@ -150,9 +153,12 @@ public class ErrorHandler {
         if (errors != null && errors.size() > 0) {
             logger.info("errors=" + errors);
             validatedElement.getStyle().setBorderColor("red");
+            String errorMsgId = "valErr-" + random.nextInt(1000000);
             Element html = new HTML(
-                    "<i class=\"fa fa-exclamation-circle\"></i> <b>" + errors.get(0) + "</b>"
+                    "<i class=\"fa fa-exclamation-circle\"></i> <b id=\"" + errorMsgId + "\">" + errors.get(0) + "</b>"
             ).getElement();
+            validatedElement.setAttribute("aria-invalid","true");
+            validatedElement.setAttribute("aria-describedBy",errorMsgId);
             html.addClassName(ERROR_CLASS);
             html.getStyle().setColor("red");
             elementToAddErrorsAfter.getParentElement().appendChild(html);


### PR DESCRIPTION
 Updates to stop double reading of field names for New Measure page and to use aria-invalid and aria-describedBy to point to the error message.