### PR TITLE
MAT-2448 Compatibility changes needed for CQFRuler. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -554,7 +554,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.16</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>

--- a/src/main/java/mat/server/service/impl/ZipPackager.java
+++ b/src/main/java/mat/server/service/impl/ZipPackager.java
@@ -18,6 +18,7 @@ import org.apache.commons.logging.Log;
 import org.apache.tools.zip.ZipEntry;
 import org.apache.tools.zip.ZipOutputStream;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.Resource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -418,6 +419,13 @@ public class ZipPackager {
         jsonParser.setPrettyPrint(true);
         var measure = jsonParser.parseResource(org.hl7.fhir.r4.model.Measure.class, measureJson);
         var libBundle = jsonParser.parseResource(Bundle.class, libBundleJson);
+
+        //For export the ids are set to the CQL LIBRARY NAME.
+        measure.setId(measure.getName());
+        libBundle.getEntry().forEach(e -> {
+            Library l = (Library) e.getResource();
+            l.setId(l.getName());
+        });
 
         Bundle result = new Bundle();
         result.getMeta().addProfile("http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/measure-bundle-cqfm");


### PR DESCRIPTION
Export measure.id and library.id are now the cql library name.