### PR TITLE
Feature/mat-2286

### DIFF
--- a/src/main/java/liquibase/FHIR_CONVERSION_HISTORY.xml
+++ b/src/main/java/liquibase/FHIR_CONVERSION_HISTORY.xml
@@ -13,7 +13,7 @@
         <createTable tableName="FHIR_CONVERSION_HISTORY">
             <column name="qdm_set_id" type="varchar(45)"/>
             <column name="fhir_set_id" type="varchar(45)"/>
-            <column name="LAST_MODIFIED_BY" type="varchar(40)"/>
+            <column name="LAST_MODIFIED_BY" type="varchar(40)" defaultValueComputed="CURRENT_TIMESTAMP"/>
             <column name="LAST_MODIFIED_ON" type="DATETIME"/>
         </createTable>
         <addPrimaryKey tableName="FHIR_CONVERSION_HISTORY" columnNames="qdm_set_id"/>

--- a/src/main/java/liquibase/LegacyFhirLibConversionHistoryInserts.xml
+++ b/src/main/java/liquibase/LegacyFhirLibConversionHistoryInserts.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet author="mat_dev_user" id="1" context="prod">
+
+        <!-- No need for SupplementalDataElement it is new for FHIR. -->
+        <!-- AdvancedIllnessandFrailtyExclusionECQM -->
+        <insert tableName="FHIR_CONVERSION_HISTORY ">
+            <column name="qdm_set_id" value="60aebe4a-ef31-4ff1-8cfb-93bd7ee79cf5"/>
+            <column name="fhir_set_id" value="B04CCC1C-4388-46F2-A440-E1901DB21A81"/>
+        </insert>
+
+        <!-- AdultOutpatientEncountersFHIR4 -->
+        <insert tableName="FHIR_CONVERSION_HISTORY ">
+            <column name="qdm_set_id" value="47bbc6ea-a2f3-421d-85ca-fae959fcbafd"/>
+            <column name="fhir_set_id" value="F1105667-B287-4DB2-A8D0-F88439E12476"/>
+        </insert>
+
+        <!-- TJCOverall -->
+        <insert tableName="FHIR_CONVERSION_HISTORY ">
+            <column name="qdm_set_id" value="d838ba65-b0cf-4494-a10f-8e4565b85137"/>
+            <column name="fhir_set_id" value="17CD49CC-2DBB-4B23-A494-3B65FA5FC3EC"/>
+        </insert>
+
+        <!-- VTEICU -->
+        <insert tableName="FHIR_CONVERSION_HISTORY ">
+            <column name="qdm_set_id" value="75d229d4-0b25-4232-88c9-93675caca343"/>
+            <column name="fhir_set_id" value="7697D333-1152-4B3C-A993-99D8B2A18743"/>
+        </insert>
+
+        <!-- Hospice -->
+        <insert tableName="FHIR_CONVERSION_HISTORY ">
+            <column name="qdm_set_id" value="64299b80-f383-4dc9-82e4-d6ef0b271b11"/>
+            <column name="fhir_set_id" value="FABC6604-264A-4DD6-AE4B-2A67C3C3B306"/>
+        </insert>
+
+        <!-- MATGlobalCommonFunctions -->
+        <insert tableName="FHIR_CONVERSION_HISTORY ">
+            <column name="qdm_set_id" value="8bdc0a19-b210-4a58-8a07-f5d95a34eca9"/>
+            <column name="fhir_set_id" value="E1DA3599-7CF7-4991-B0E0-D3ED63239836"/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/java/liquibase/LegacyFhirLibConversionHistoryInserts.xml
+++ b/src/main/java/liquibase/LegacyFhirLibConversionHistoryInserts.xml
@@ -8,39 +8,39 @@
 
         <!-- No need for SupplementalDataElement it is new for FHIR. -->
         <!-- AdvancedIllnessandFrailtyExclusionECQM -->
-        <insert tableName="FHIR_CONVERSION_HISTORY ">
+        <insert tableName="FHIR_CONVERSION_HISTORY">
             <column name="qdm_set_id" value="60aebe4a-ef31-4ff1-8cfb-93bd7ee79cf5"/>
-            <column name="fhir_set_id" value="B04CCC1C-4388-46F2-A440-E1901DB21A81"/>
+            <column name="fhir_set_id" value="0445f523-6e51-4de8-9487-920e977ed928"/>
         </insert>
 
         <!-- AdultOutpatientEncountersFHIR4 -->
-        <insert tableName="FHIR_CONVERSION_HISTORY ">
+        <insert tableName="FHIR_CONVERSION_HISTORY">
             <column name="qdm_set_id" value="47bbc6ea-a2f3-421d-85ca-fae959fcbafd"/>
-            <column name="fhir_set_id" value="F1105667-B287-4DB2-A8D0-F88439E12476"/>
+            <column name="fhir_set_id" value="225b9882-8a50-44a7-88e6-139ad91bfc5c"/>
         </insert>
 
         <!-- TJCOverall -->
-        <insert tableName="FHIR_CONVERSION_HISTORY ">
+        <insert tableName="FHIR_CONVERSION_HISTORY">
             <column name="qdm_set_id" value="d838ba65-b0cf-4494-a10f-8e4565b85137"/>
-            <column name="fhir_set_id" value="17CD49CC-2DBB-4B23-A494-3B65FA5FC3EC"/>
+            <column name="fhir_set_id" value="3efa5c8b-fe00-40c9-9fd3-bcfd5d8e4dcf"/>
         </insert>
 
         <!-- VTEICU -->
-        <insert tableName="FHIR_CONVERSION_HISTORY ">
+        <insert tableName="FHIR_CONVERSION_HISTORY">
             <column name="qdm_set_id" value="75d229d4-0b25-4232-88c9-93675caca343"/>
-            <column name="fhir_set_id" value="7697D333-1152-4B3C-A993-99D8B2A18743"/>
+            <column name="fhir_set_id" value="d316defe-b0c4-4d41-b41c-181c89678e27"/>
         </insert>
 
         <!-- Hospice -->
-        <insert tableName="FHIR_CONVERSION_HISTORY ">
+        <insert tableName="FHIR_CONVERSION_HISTORY">
             <column name="qdm_set_id" value="64299b80-f383-4dc9-82e4-d6ef0b271b11"/>
-            <column name="fhir_set_id" value="FABC6604-264A-4DD6-AE4B-2A67C3C3B306"/>
+            <column name="fhir_set_id" value="26ec7468-92da-46e2-8518-b12516724113"/>
         </insert>
 
         <!-- MATGlobalCommonFunctions -->
-        <insert tableName="FHIR_CONVERSION_HISTORY ">
+        <insert tableName="FHIR_CONVERSION_HISTORY">
             <column name="qdm_set_id" value="8bdc0a19-b210-4a58-8a07-f5d95a34eca9"/>
-            <column name="fhir_set_id" value="E1DA3599-7CF7-4991-B0E0-D3ED63239836"/>
+            <column name="fhir_set_id" value="bd592049-5371-4900-b391-99aa96fd9a89"/>
         </insert>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/java/liquibase/changelog.xml
+++ b/src/main/java/liquibase/changelog.xml
@@ -5,5 +5,5 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
 			http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
     <include file="classpath:/liquibase/FHIR_CONVERSION_HISTORY.xml"/>
-    <include file="classpath:/liquibase/LegacyFhirConversionHistoryInserts.xml"/>
+    <include file="classpath:/liquibase/LegacyFhirLibConversionHistoryInserts.xml"/>
 </databaseChangeLog>

--- a/src/main/java/liquibase/changelog.xml
+++ b/src/main/java/liquibase/changelog.xml
@@ -5,4 +5,5 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
 			http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
     <include file="classpath:/liquibase/FHIR_CONVERSION_HISTORY.xml"/>
+    <include file="classpath:/liquibase/LegacyFhirConversionHistoryInserts.xml"/>
 </databaseChangeLog>

--- a/src/main/java/mat/client/CqlLibraryPresenter.java
+++ b/src/main/java/mat/client/CqlLibraryPresenter.java
@@ -629,27 +629,7 @@ public class CqlLibraryPresenter implements MatPresenter, TabObserver {
             @Override
             public void onConvertClicked(CQLLibraryDataSetObject object) {
                 showSearchingBusy(true);
-                MatContext.get().getCQLLibraryService().checkLibraryForConversion(object, new AsyncCallback<CheckForConversionResult>() {
-
-                    @Override
-                    public void onFailure(Throwable caught) {
-                        logger.log(Level.SEVERE, "Error while checking a draft for the library set " + object.getCqlSetId() + ". Error message: " + caught.getMessage(), caught);
-                        showErrorAlertDialogBox(MatContext.get().getMessageDelegate().getGenericErrorMessage(), false);
-                        MatContext.get().recordTransactionEvent(null, null, null, UNHANDLED_EXCEPTION + caught.getLocalizedMessage(), 0);
-                    }
-
-                    @Override
-                    public void onSuccess(CheckForConversionResult result) {
-                        logger.log(Level.WARNING, "Result is " + result);
-                        if (result.isProceedImmediately()) {
-                            convertCqlLibraryFhir(object);
-                        } else if (result.isConfirmBeforeProceed()) {
-                            confirmAndConvertFhir(object);
-                        } else {
-                            showErrorAlertDialogBox(MatContext.get().getMessageDelegate().getConversionBlockedWithDraftsErrorMessageForCqlLibrary(), false);
-                        }
-                    }
-                });
+                convertCqlLibraryFhir(object);
             }
 
 

--- a/src/main/java/mat/client/measure/service/CQLLibraryService.java
+++ b/src/main/java/mat/client/measure/service/CQLLibraryService.java
@@ -108,7 +108,5 @@ public interface CQLLibraryService extends RemoteService {
 	CQLQualityDataModelWrapper saveValueSetList(List<CQLValueSetTransferObject> transferObjectList,
 			List<CQLQualityDataSetDTO> appliedValueSetList, String cqlLibraryId);
 
-    CheckForConversionResult checkLibraryForConversion(CQLLibraryDataSetObject object);
-
     FhirConvertResultResponse convertCqlLibrary(CQLLibraryDataSetObject object) throws MatException;
 }

--- a/src/main/java/mat/client/measure/service/CQLLibraryServiceAsync.java
+++ b/src/main/java/mat/client/measure/service/CQLLibraryServiceAsync.java
@@ -117,7 +117,5 @@ public interface CQLLibraryServiceAsync {
 			List<CQLQualityDataSetDTO> appliedValueSetList, String cqlLibraryId,
 			AsyncCallback<CQLQualityDataModelWrapper> callback);
 
-    void checkLibraryForConversion(CQLLibraryDataSetObject object, AsyncCallback<CheckForConversionResult> checkMeasureForConversionResultAsyncCallback);
-
     void convertCqlLibrary(CQLLibraryDataSetObject object, AsyncCallback<FhirConvertResultResponse> fhirConvertResultResponseAsyncCallback);
 }

--- a/src/main/java/mat/dao/FhirConversionHistoryDao.java
+++ b/src/main/java/mat/dao/FhirConversionHistoryDao.java
@@ -3,4 +3,5 @@ package mat.dao;
 import mat.model.clause.FhirConversionHistory;
 
 public interface FhirConversionHistoryDao extends  IDAO<FhirConversionHistory, String> {
+    FhirConversionHistory lookupByQdmSetId(String qdmSetId);
 }

--- a/src/main/java/mat/dao/clause/CQLLibraryDAO.java
+++ b/src/main/java/mat/dao/clause/CQLLibraryDAO.java
@@ -12,6 +12,8 @@ import java.util.List;
 
 public interface CQLLibraryDAO extends IDAO<CQLLibrary, String>{
 
+	boolean existsWithSetId(String setId);
+
 	List<CQLLibraryShareDTO> search(LibrarySearchModel librarySearchModel, int pageSize, User user);
 
 	boolean isLibraryLocked(String id);

--- a/src/main/java/mat/dao/clause/MeasureDAO.java
+++ b/src/main/java/mat/dao/clause/MeasureDAO.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import java.util.Set;
 
 public interface MeasureDAO extends IDAO<Measure, String> {
+    boolean existsWithSetId(String setId);
+
     /**
      * Count users for measure share.
      *

--- a/src/main/java/mat/dao/clause/impl/CQLLibraryDAOImpl.java
+++ b/src/main/java/mat/dao/clause/impl/CQLLibraryDAOImpl.java
@@ -27,28 +27,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.NoResultException;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaDelete;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Join;
-import javax.persistence.criteria.JoinType;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
-import javax.persistence.criteria.Subquery;
+import javax.persistence.criteria.*;
 import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 @Repository("cqlLibraryDAO")
@@ -110,6 +94,20 @@ public class CQLLibraryDAOImpl extends GenericDAO<CQLLibrary, String> implements
     }
 
     private static final long LOCK_THRESHOLD = TimeUnit.MINUTES.toMillis(3); // 3 minutes
+
+    @Override
+    public boolean existsWithSetId(String setId) {
+        final Session session = getSessionFactory().getCurrentSession();
+        final CriteriaBuilder cb = session.getCriteriaBuilder();
+        CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
+        final Root<CQLLibrary> root = countQuery.from(CQLLibrary.class);
+
+        countQuery = countQuery.select(cb.count(root)).where(cb.equal(root.get("setId"),setId));
+
+        final Long count = session.createQuery(countQuery).getSingleResult();
+
+        return (count == null) ? false : count > 0;
+    }
 
     @Override
     public List<CQLLibrary> searchForIncludes(String setId, String libraryName, String searchText, String modelType) {

--- a/src/main/java/mat/dao/clause/impl/MeasureDAOImpl.java
+++ b/src/main/java/mat/dao/clause/impl/MeasureDAOImpl.java
@@ -89,6 +89,20 @@ public class MeasureDAOImpl extends GenericDAO<Measure, String> implements Measu
     }
 
     @Override
+    public boolean existsWithSetId(String setId) {
+        final Session session = getSessionFactory().getCurrentSession();
+        final CriteriaBuilder cb = session.getCriteriaBuilder();
+        CriteriaQuery<Long> countQuery = cb.createQuery(Long.class);
+        final Root<Measure> root = countQuery.from(Measure.class);
+
+        countQuery = countQuery.select(cb.count(root)).where(cb.equal(root.get("measureSet").get(ID),setId));
+
+        final Long count = session.createQuery(countQuery).getSingleResult();
+
+        return (count == null) ? false : count > 0;
+    }
+
+    @Override
     public List<Measure> getMeasureListForMeasureOwner(User user) {
         final Session session = getSessionFactory().getCurrentSession();
         final CriteriaBuilder cb = session.getCriteriaBuilder();

--- a/src/main/java/mat/dao/impl/FhirConversionHistoryDaoImpl.java
+++ b/src/main/java/mat/dao/impl/FhirConversionHistoryDaoImpl.java
@@ -2,9 +2,26 @@ package mat.dao.impl;
 
 import mat.dao.FhirConversionHistoryDao;
 import mat.dao.search.GenericDAO;
+import mat.model.MeasureType;
 import mat.model.clause.FhirConversionHistory;
+import org.hibernate.Session;
 import org.springframework.stereotype.Repository;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
 
 @Repository
 public class FhirConversionHistoryDaoImpl extends GenericDAO<FhirConversionHistory, String> implements FhirConversionHistoryDao {
+    @Override
+    public FhirConversionHistory lookupByQdmSetId(String qdmSetId) {
+        Session session = getSessionFactory().getCurrentSession();
+        CriteriaBuilder cb = session.getCriteriaBuilder();
+        CriteriaQuery<FhirConversionHistory> query = cb.createQuery(FhirConversionHistory.class);
+        Root<FhirConversionHistory> root = query.from(FhirConversionHistory.class);
+
+        query.select(root).where(cb.equal(root.get("qdmSetId"), qdmSetId));
+
+        return session.createQuery(query).uniqueResult();
+    }
 }

--- a/src/main/java/mat/server/CQLLibraryService.java
+++ b/src/main/java/mat/server/CQLLibraryService.java
@@ -568,28 +568,6 @@ public class CQLLibraryService extends SpringRemoteServiceServlet implements CQL
     }
 
     @Override
-    public CheckForConversionResult checkLibraryForConversion(CQLLibraryDataSetObject sourceLibrary) {
-        try {
-            log.debug("checkLibraryForConversion  libraryId: " + sourceLibrary.getId() + " setId: " + sourceLibrary.getCqlSetId());
-            CheckForConversionResult result = new CheckForConversionResult();
-            List<CQLLibrary> draftLibraries = cqlLibraryDAO.getDraftLibraryBySet(sourceLibrary.getCqlSetId());
-            if (draftLibraries.isEmpty()) {
-                // If no drafts found we can proceed with conversion
-                result.setProceedImmediately(true);
-            } else {
-                // If the only draft is a FHIR draft created from the same source measure then ask for confirmation to override.
-                // UI cannot proceed with conversion if User didn't confirm or if there is/are other draft(s)
-                result.setConfirmBeforeProceed(draftLibraries.stream().allMatch(m -> m.isFhirLibrary() && StringUtils.equals(sourceLibrary.getCqlSetId(), m.getSetId())));
-            }
-
-            return result;
-        } catch (RuntimeException re) {
-            log.error("checkLibraryForConversion", re);
-            throw re;
-        }
-    }
-
-    @Override
     public FhirConvertResultResponse convertCqlLibrary(CQLLibraryDataSetObject sourceLibrary) throws MatException {
         log.debug("Converting  libraryId: " + sourceLibrary.getId());
         try {

--- a/src/main/java/mat/server/CQLLibraryServiceImpl.java
+++ b/src/main/java/mat/server/CQLLibraryServiceImpl.java
@@ -252,11 +252,6 @@ public class CQLLibraryServiceImpl extends SpringRemoteServiceServlet implements
     }
 
     @Override
-    public CheckForConversionResult checkLibraryForConversion(CQLLibraryDataSetObject object) {
-        return this.getCQLLibraryService().checkLibraryForConversion(object);
-    }
-
-    @Override
     public FhirConvertResultResponse convertCqlLibrary(CQLLibraryDataSetObject object) throws MatException {
         return this.getCQLLibraryService().convertCqlLibrary(object);
     }

--- a/src/main/java/mat/server/service/CQLLibraryServiceInterface.java
+++ b/src/main/java/mat/server/service/CQLLibraryServiceInterface.java
@@ -133,8 +133,6 @@ public interface CQLLibraryServiceInterface {
 
     void saveFhirCQLLibraryExport(CQLLibrary cqlLibrary, FhirLibraryPackageResult fhirPackageResults);
 
-    CheckForConversionResult checkLibraryForConversion(CQLLibraryDataSetObject object);
-
     FhirConvertResultResponse convertCqlLibrary(CQLLibraryDataSetObject object) throws MatException;
 
     int deleteDraftFhirLibrariesBySetId(String setId);

--- a/src/main/java/mat/server/service/impl/FhirCqlLibraryServiceImpl.java
+++ b/src/main/java/mat/server/service/impl/FhirCqlLibraryServiceImpl.java
@@ -124,9 +124,6 @@ public class FhirCqlLibraryServiceImpl implements FhirCqlLibraryService {
 
         CQLLibrary existingLibrary = cqlLibraryDAO.find(sourceLibrary.getId());
 
-        /*if draft FHIR library already exists then delete it */
-        deleteDraftFhirLibrariesInSet(existingLibrary.getSetId());
-
         ConversionResultDto conversionResult = fhirLibRemote.convert(sourceLibrary.getId(), ConversionType.CONVERSION);
         Optional<String> fhirCqlOpt = getFhirCql(conversionResult);
 
@@ -204,12 +201,6 @@ public class FhirCqlLibraryServiceImpl implements FhirCqlLibraryService {
                 "Converted from QDM/CQL to FHIR",
                 newFhirLibrary.getName() + " FHIR DRAFT 0.0.000 was created by converting from QDM Version " + existingLibrary.getMatVersion(),
                 false);
-    }
-
-    public void deleteDraftFhirLibrariesInSet(String setId) {
-        logger.debug("deleteDraftFhirLibrariesInSet : setId = " + setId);
-        int removed = cqlLibService.deleteDraftFhirLibrariesBySetId(setId);
-        logger.debug("deleteDraftFhirLibrariesInSet : removed " + removed);
     }
 
     private String generateCqlXml(CQLLibrary existingLibrary, CQLLibrary newFhirLibrary, String newCql) throws MarshalException, MappingException, ValidationException, IOException {

--- a/src/test/java/mat/server/CQLLibraryServiceTest.java
+++ b/src/test/java/mat/server/CQLLibraryServiceTest.java
@@ -38,61 +38,6 @@ class CQLLibraryServiceTest {
     @InjectMocks
     private CQLLibraryService cqlLibraryService;
 
-    @Test
-    public void testCheckLibraryForConversionNoDraftLibraries() {
-        CQLLibraryDataSetObject cqlLibraryDataSetObject = new CQLLibraryDataSetObject();
-        cqlLibraryDataSetObject.setId("libraryId");
-        cqlLibraryDataSetObject.setCqlSetId("cqlLibrarySetId");
-
-        List<CQLLibrary> cqlLibraries = new ArrayList<>();
-
-        Mockito.when(cqlLibraryDAO.getDraftLibraryBySet(cqlLibraryDataSetObject.getCqlSetId())).thenReturn(cqlLibraries);
-
-        CheckForConversionResult actualResult = cqlLibraryService.checkLibraryForConversion(cqlLibraryDataSetObject);
-
-        assertTrue(actualResult.isProceedImmediately());
-    }
-
-    @Test
-    public void testCheckLibraryForConversionFhirDraft() {
-        CQLLibraryDataSetObject cqlLibraryDataSetObject = new CQLLibraryDataSetObject();
-        cqlLibraryDataSetObject.setId("libraryId");
-        cqlLibraryDataSetObject.setCqlSetId("cqlLibrarySetId");
-
-        CQLLibrary cqlLibrary = new CQLLibrary();
-        cqlLibrary.setLibraryModelType(ModelTypeHelper.FHIR);
-        cqlLibrary.setSetId("cqlLibrarySetId");
-
-        List<CQLLibrary> cqlLibraries = new ArrayList<>();
-        cqlLibraries.add(cqlLibrary);
-
-        Mockito.when(cqlLibraryDAO.getDraftLibraryBySet(cqlLibraryDataSetObject.getCqlSetId())).thenReturn(cqlLibraries);
-
-        CheckForConversionResult actualResult = cqlLibraryService.checkLibraryForConversion(cqlLibraryDataSetObject);
-
-        assertTrue(actualResult.isConfirmBeforeProceed());
-    }
-
-    @Test
-    public void testCheckLibraryForConversionQDMDraft() {
-        CQLLibraryDataSetObject cqlLibraryDataSetObject = new CQLLibraryDataSetObject();
-        cqlLibraryDataSetObject.setId("libraryId");
-        cqlLibraryDataSetObject.setCqlSetId("cqlLibrarySetId");
-
-        CQLLibrary cqlLibrary = new CQLLibrary();
-        cqlLibrary.setLibraryModelType(ModelTypeHelper.QDM);
-        cqlLibrary.setSetId("cqlLibrarySetId");
-
-        List<CQLLibrary> cqlLibraries = new ArrayList<>();
-        cqlLibraries.add(cqlLibrary);
-
-        Mockito.when(cqlLibraryDAO.getDraftLibraryBySet(cqlLibraryDataSetObject.getCqlSetId())).thenReturn(cqlLibraries);
-
-        CheckForConversionResult actualResult = cqlLibraryService.checkLibraryForConversion(cqlLibraryDataSetObject);
-
-        assertFalse(actualResult.isConfirmBeforeProceed());
-        assertFalse(actualResult.isProceedImmediately());
-    }
 
     @Test
     public void testConvertCqlLibrary() throws MatException, MarshalException, MappingException, ValidationException, IOException {


### PR DESCRIPTION
Added liquabase to auto link pre existing common libs we created as part of MAT ON FHIR.
Updated isConvertible checks for measures and libs to check for a fhir_set_id in FHIR_CONVERSION_HISTORY and also that a lib or measure exits.
Removed functionality to delete existing draft. You can only convert once and that code needed to be removed.