### PR TITLE
BUGFIX PR for what is needed to get MAT to compile with latest cqframework 1.5.2-SNAPSHOT.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <gwtbootstrap3.extra.version>1.0.2</gwtbootstrap3.extra.version>
         <elemental.version>1.1.0</elemental.version>
         <gwt.elemento.version>0.9.6-gwt2</gwt.elemento.version>
-        <cqframework.version>1.4.6</cqframework.version>
+        <cqframework.version>1.5.2-SNAPSHOT</cqframework.version>
         <axis.version>1.7.9</axis.version>
         <castor.version>1.4.1</castor.version>
         <slf4j.version>1.7.30</slf4j.version>
@@ -122,10 +122,11 @@
             <artifactId>qdm</artifactId>
             <version>${cqframework.version}</version>
         </dependency>
+        <!-- TO DO why is this no longer in 1.5.2-SNAPSHOT. Do we even need it? -->
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>cql-formatter</artifactId>
-            <version>${cqframework.version}</version>
+            <version>1.4.6</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/cqltoelm/CQLtoELM.java
+++ b/src/main/java/cqltoelm/CQLtoELM.java
@@ -6,11 +6,7 @@ import cqltoelm.parsers.TrackbackListener;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
-import org.cqframework.cql.cql2elm.CqlTranslator;
-import org.cqframework.cql.cql2elm.CqlTranslatorException;
-import org.cqframework.cql.cql2elm.DefaultLibrarySourceProvider;
-import org.cqframework.cql.cql2elm.LibraryManager;
-import org.cqframework.cql.cql2elm.ModelManager;
+import org.cqframework.cql.cql2elm.*;
 import org.cqframework.cql.cql2elm.model.TranslatedLibrary;
 import org.cqframework.cql.elm.tracking.TrackBack;
 import org.cqframework.cql.gen.cqlLexer;
@@ -361,7 +357,8 @@ public class CQLtoELM {
                 identifier.setId(include.getPath());
                 identifier.setVersion(include.getVersion());
                 try {
-                    TranslatedLibrary childLibrary = libraryManager.resolveLibrary(identifier, new ArrayList<>());
+                    //TO DO: make sure this options is correct for QDM 5.6.
+                    TranslatedLibrary childLibrary = libraryManager.resolveLibrary(identifier, new CqlTranslatorOptions(),new ArrayList<>());
                     fetchTranslatedLibraries(childLibrary);
                 } catch (Exception e) {
                     System.out.println(e.getMessage());

--- a/src/main/java/mat/server/cqlparser/CQLFilter.java
+++ b/src/main/java/mat/server/cqlparser/CQLFilter.java
@@ -10,52 +10,7 @@ import org.cqframework.cql.cql2elm.QdmModelInfoProvider;
 import org.hl7.cql.model.ClassType;
 import org.hl7.cql.model.DataType;
 import org.hl7.cql.model.ListType;
-import org.hl7.elm.r1.AggregateExpression;
-import org.hl7.elm.r1.AliasedQuerySource;
-import org.hl7.elm.r1.BinaryExpression;
-import org.hl7.elm.r1.ByExpression;
-import org.hl7.elm.r1.Case;
-import org.hl7.elm.r1.CaseItem;
-import org.hl7.elm.r1.CodeRef;
-import org.hl7.elm.r1.CodeSystemRef;
-import org.hl7.elm.r1.Combine;
-import org.hl7.elm.r1.Expression;
-import org.hl7.elm.r1.ExpressionDef;
-import org.hl7.elm.r1.ExpressionRef;
-import org.hl7.elm.r1.Filter;
-import org.hl7.elm.r1.First;
-import org.hl7.elm.r1.ForEach;
-import org.hl7.elm.r1.FunctionDef;
-import org.hl7.elm.r1.FunctionRef;
-import org.hl7.elm.r1.If;
-import org.hl7.elm.r1.InCodeSystem;
-import org.hl7.elm.r1.InValueSet;
-import org.hl7.elm.r1.IncludeDef;
-import org.hl7.elm.r1.IndexOf;
-import org.hl7.elm.r1.Instance;
-import org.hl7.elm.r1.InstanceElement;
-import org.hl7.elm.r1.Interval;
-import org.hl7.elm.r1.Last;
-import org.hl7.elm.r1.LetClause;
-import org.hl7.elm.r1.Library;
-import org.hl7.elm.r1.NaryExpression;
-import org.hl7.elm.r1.OperandDef;
-import org.hl7.elm.r1.ParameterDef;
-import org.hl7.elm.r1.ParameterRef;
-import org.hl7.elm.r1.PositionOf;
-import org.hl7.elm.r1.Property;
-import org.hl7.elm.r1.Query;
-import org.hl7.elm.r1.RelationshipClause;
-import org.hl7.elm.r1.Retrieve;
-import org.hl7.elm.r1.Round;
-import org.hl7.elm.r1.Sort;
-import org.hl7.elm.r1.SortByItem;
-import org.hl7.elm.r1.TernaryExpression;
-import org.hl7.elm.r1.ToList;
-import org.hl7.elm.r1.Tuple;
-import org.hl7.elm.r1.TupleElement;
-import org.hl7.elm.r1.UnaryExpression;
-import org.hl7.elm.r1.ValueSetRef;
+import org.hl7.elm.r1.*;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 import org.hl7.elm_modelinfo.r1.ProfileInfo;
 import org.hl7.elm_modelinfo.r1.TypeInfo;
@@ -734,10 +689,10 @@ public class CQLFilter {
 	private void checkForInValuesets(Expression expression) {
 		InValueSet inValueSet = (InValueSet) expression;
 		// System.out.println("\t" + inValueSet.getValueset().getName());
-		String name = inValueSet.getValueset().getName();
+		String name =  ((IdentifierRef) inValueSet.getValueset()).getName();
 
 		
-		String libraryAlias = inValueSet.getValueset().getLibraryName();
+		String libraryAlias = ((IdentifierRef) inValueSet.getValueset()).getLibraryName();
 
 		if (libraryAlias != null) {
 			LibraryInfoHolder libHolder = getIncludedLibrary(libraryAlias);
@@ -822,7 +777,7 @@ public class CQLFilter {
 	private void checkForInCodeSystem(Expression expression) {
 		InCodeSystem inCodeSystem = (InCodeSystem) expression;
 		
-		String name = inCodeSystem.getCodesystem().getName();
+		String name = ((IdentifierRef) inCodeSystem.getCodesystem()).getName();
 
 		if (this.currentLibraryHolder.getLibraryAlias().length() > 0) {
 			name =  this.currentLibraryHolder.getLibraryName() + "-" + this.currentLibraryHolder.getLibraryVersion() + 

--- a/super-dev-mode/pom.xml
+++ b/super-dev-mode/pom.xml
@@ -24,7 +24,7 @@
         <gwtbootstrap3.extra.version>1.0.2</gwtbootstrap3.extra.version>
         <elemental.version>1.1.0</elemental.version>
         <gwt.elemento.version>0.9.6-gwt2</gwt.elemento.version>
-        <cqframework.version>1.4.6</cqframework.version>
+        <cqframework.version>1.5.2-SNAPSHOT</cqframework.version>
         <axis.version>1.7.9</axis.version>
         <castor.version>1.4.1</castor.version>
         <slf4j.version>1.7.30</slf4j.version>
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>cql-formatter</artifactId>
-            <version>${cqframework.version}</version>
+            <version>1.4.6</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
There are still issues to fix after this it will just get it running.

**Warning**  Do not merge until you are ready to tackle this. It was just created to show how to do it for when it is needed in QDM 5.6 update.

**Example of issues that still need to be fixed when loading a QDM measure this occurs:**
Caused by: java.lang.ClassCastException: class org.hl7.elm_modelinfo.r1.ListTypeSpecifier cannot be cast to class org.hl7.elm_modelinfo.r1.ChoiceTypeSpecifier (org.hl7.elm_modelinfo.r1.ListTypeSpecifier and org.hl7.elm_modelinfo.r1.ChoiceTypeSpecifier are in unnamed module of loader org.apache.catalina.loader.ParallelWebappClassLoader @66aa2959)
	at mat.server.util.QDMUtil.getAttributesFromChoiceTypeSpecifier(QDMUtil.java:121)
	at mat.server.util.QDMUtil.collectAttributeTypeInformation(QDMUtil.java:107)
	at mat.server.util.QDMUtil.lambda$getQDMContainer$0(QDMUtil.java:89)
	at java.base/java.util.HashMap.forEach(HashMap.java:1336)
	at mat.server.util.QDMUtil.getQDMContainer(QDMUtil.java:60)
	at mat.server.CQLConstantServiceImpl.getQDMInformation(CQLConstantServiceImpl.java:270)
	at mat.server.CQLConstantServiceImpl.getAllCQLConstants(CQLConstantServiceImpl.java:152)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at com.google.gwt.user.server.rpc.RPC.invokeAndEncodeResponse(RPC.java:587)
	... 84 more