### PR TITLE
Removed Cql Editor Tooltip

### DIFF
--- a/src/main/java/mat/client/cqlworkspace/shared/CQLEditorPanel.java
+++ b/src/main/java/mat/client/cqlworkspace/shared/CQLEditorPanel.java
@@ -29,7 +29,6 @@ public class CQLEditorPanel extends Composite {
 		this.isReadOnly = isReadOnly;
 		this.editor = new CQLEditor(isReadOnly);
 		this.editor.getElement().getElementsByTagName("textarea").getItem(0).setTitle(text);
-		this.editor.getElement().setTitle(text);
 		initWidget(buildWidget());
 	}
 	


### PR DESCRIPTION
This change removes the Tooltip "CQL Library Editor" 
Technically removing a Title tag, Tested with Google Chrome screen Reader, not impacted

https://jira.cms.gov/browse/MAT-2464