### PR TITLE
NPE while retrieving Datatype

### DIFF
--- a/src/main/java/mat/server/humanreadable/helper/DataRequirementsNoValueSetFilter.java
+++ b/src/main/java/mat/server/humanreadable/helper/DataRequirementsNoValueSetFilter.java
@@ -3,6 +3,7 @@ package mat.server.humanreadable.helper;
 import mat.server.humanreadable.cql.HumanReadableTerminologyModel;
 import mat.server.humanreadable.cql.HumanReadableValuesetModel;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -39,6 +40,7 @@ public class DataRequirementsNoValueSetFilter {
             return true;
         } else {
             return valuesetAndCodeDataCriteriaList.stream()
+                    .filter(v -> StringUtils.isNotBlank(v.getDatatype()))
                     .filter(v -> v.getDatatype().equals(dataRequirementsNoValue))
                     .findAny().isEmpty();
 


### PR DESCRIPTION
<!--- Provide the JIRA ticket number and a general summary of your changes in the Title above -->
Bug Fix
## Description
<!--- Describe your changes in detail -->
valuesetAndCodeDataCriteriaList.getDatatype() is null so added a null check prior
## JIRA Ticket
<!--- Link to JIRA ticket -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
- [x] None applicable
