### PR TITLE
Revert "Bump mysql-connector-java from 8.0.22 to 8.0.23"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.23</version>
+            <version>8.0.22</version>
         </dependency>
         <dependency>
             <groupId>org.freemarker</groupId>


### PR DESCRIPTION
Reverts MeasureAuthoringTool/MeasureAuthoringTool#521

Liquibase started having issues around the time of this merge. Reverting to verify if this is cause.