### PR TITLE
Update CQFramework Dependency to 1.4.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <gwtbootstrap3.extra.version>1.0.2</gwtbootstrap3.extra.version>
         <elemental.version>1.1.0</elemental.version>
         <gwt.elemento.version>0.9.6-gwt2</gwt.elemento.version>
-        <cqframework.version>1.4.6</cqframework.version>
+        <cqframework.version>1.4.8</cqframework.version>
         <axis.version>1.7.9</axis.version>
         <castor.version>1.4.1</castor.version>
         <slf4j.version>1.7.30</slf4j.version>

--- a/src/main/java/cqltoelm/CQLtoELM.java
+++ b/src/main/java/cqltoelm/CQLtoELM.java
@@ -9,6 +9,7 @@ import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.CqlTranslatorException;
 import org.cqframework.cql.cql2elm.DefaultLibrarySourceProvider;
+import org.cqframework.cql.cql2elm.LibraryBuilder;
 import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.cql2elm.ModelManager;
 import org.cqframework.cql.cql2elm.model.TranslatedLibrary;
@@ -361,7 +362,11 @@ public class CQLtoELM {
                 identifier.setId(include.getPath());
                 identifier.setVersion(include.getVersion());
                 try {
-                    TranslatedLibrary childLibrary = libraryManager.resolveLibrary(identifier, new ArrayList<>());
+                    TranslatedLibrary childLibrary = libraryManager.resolveLibrary(identifier,
+                            CqlTranslatorException.ErrorSeverity.Info,
+                            LibraryBuilder.SignatureLevel.None,
+                            new CqlTranslator.Options[0],
+                            new ArrayList<>());
                     fetchTranslatedLibraries(childLibrary);
                 } catch (Exception e) {
                     System.out.println(e.getMessage());

--- a/super-dev-mode/pom.xml
+++ b/super-dev-mode/pom.xml
@@ -24,7 +24,7 @@
         <gwtbootstrap3.extra.version>1.0.2</gwtbootstrap3.extra.version>
         <elemental.version>1.1.0</elemental.version>
         <gwt.elemento.version>0.9.6-gwt2</gwt.elemento.version>
-        <cqframework.version>1.4.6</cqframework.version>
+        <cqframework.version>1.4.9</cqframework.version>
         <axis.version>1.7.9</axis.version>
         <castor.version>1.4.1</castor.version>
         <slf4j.version>1.7.30</slf4j.version>

--- a/super-dev-mode/pom.xml
+++ b/super-dev-mode/pom.xml
@@ -24,7 +24,7 @@
         <gwtbootstrap3.extra.version>1.0.2</gwtbootstrap3.extra.version>
         <elemental.version>1.1.0</elemental.version>
         <gwt.elemento.version>0.9.6-gwt2</gwt.elemento.version>
-        <cqframework.version>1.4.9</cqframework.version>
+        <cqframework.version>1.4.8</cqframework.version>
         <axis.version>1.7.9</axis.version>
         <castor.version>1.4.1</castor.version>
         <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
- fix: super-dev-mode/pom.xml to reduce vulnerabilities
- fix: pom.xml to reduce vulnerabilities
- Upgrade cqframework to 1.4.8 to resolve multiple security vulnerabilities

<!--- Provide the JIRA ticket number and a general summary of your changes in the Title above -->

## Description
Updating the cqframework dependency in MAT to 1.4.8 to resolve a whole slew of security issues stemming from the Jackson JSON/XML parsing dependencies used by the cqframework.
<!--- Describe your changes in detail -->

## JIRA Ticket
<!--- Link to JIRA ticket -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [x] Tests have been run locally and pass.

## Screenshots (if appropriate)
- [ ] None applicable
