### PR TITLE
[MAT-2731] Check for Code when identifying Data Requirements that do not have a CodeFilter

### DIFF
--- a/src/main/java/mat/server/service/impl/SimpleEMeasureServiceImpl.java
+++ b/src/main/java/mat/server/service/impl/SimpleEMeasureServiceImpl.java
@@ -552,13 +552,13 @@ public class SimpleEMeasureServiceImpl implements SimpleEMeasureService {
     public final ExportResult getHumanReadable(final String measureId, final String measureVersionNumber) throws Exception {
         MeasureExport measureExport = getMeasureExport(measureId);
 
-        List<String> dataRequirementsNoValueSet = new ArrayList<>();
+        List<String> dataRequirementsNoCodeFilter = new ArrayList<>();
         if (measureExport.isFhir()) {
             ZipPackager zp = context.getBean(ZipPackagerFactory.class).getZipPackager();
-            String measureJsonBundle = zp.buildFhirMeasureJsonBundle(measureId);
-            dataRequirementsNoValueSet = new ExportResultParser(measureJsonBundle).parseDataRequirement();
+            String bundleJson = zp.buildFhirMeasureJsonBundle(measureId);
+            dataRequirementsNoCodeFilter = new ExportResultParser(bundleJson).parseDataRequirement();
         }
-        String emeasureHTMLStr = getHumanReadableForMeasure(measureId, measureExport.getSimpleXML(), measureVersionNumber, dataRequirementsNoValueSet);
+        String emeasureHTMLStr = getHumanReadableForMeasure(measureId, measureExport.getSimpleXML(), measureVersionNumber, dataRequirementsNoCodeFilter);
 
         ExportResult exportResult = new ExportResult();
         exportResult.export = emeasureHTMLStr;
@@ -570,13 +570,13 @@ public class SimpleEMeasureServiceImpl implements SimpleEMeasureService {
     public final ExportResult createOrGetHumanReadable(final String measureId, final String measureVersionNumber) throws Exception {
         MeasureExport measureExport = getMeasureExport(measureId);
         if (measureExport.getHumanReadable() == null) {
-            List<String> dataRequirementsNoValueSet = new ArrayList<>();
+            List<String> dataRequirementsNoCodeFilter = new ArrayList<>();
             if (measureExport.isFhir()) {
                 ZipPackager zp = context.getBean(ZipPackagerFactory.class).getZipPackager();
-                String measureJsonBundle = zp.buildFhirMeasureJsonBundle(measureId);
-                dataRequirementsNoValueSet = new ExportResultParser(measureJsonBundle).parseDataRequirement();
+                String bundleJson = zp.buildFhirMeasureJsonBundle(measureId);
+                dataRequirementsNoCodeFilter = new ExportResultParser(bundleJson).parseDataRequirement();
             }
-            measureExport.setHumanReadable(getHumanReadableForMeasure(measureId, measureExport.getSimpleXML(), measureVersionNumber, dataRequirementsNoValueSet));
+            measureExport.setHumanReadable(getHumanReadableForMeasure(measureId, measureExport.getSimpleXML(), measureVersionNumber, dataRequirementsNoCodeFilter));
             measureExportDAO.save(measureExport);
         }
 

--- a/src/main/java/mat/server/service/impl/helper/ExportResultParser.java
+++ b/src/main/java/mat/server/service/impl/helper/ExportResultParser.java
@@ -11,6 +11,18 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
+/**
+ * Reads over the Data Requirements for a FHIR measure and builds a
+ * unique List of Data Requirements that do not have a backing Value Set
+ * or Direct Reference Code (DRC).
+ *
+ * A Data Requirement is considered to be without a Value Set or Code when
+ * either the Data Requirement's Code Filter is null OR its Code Filter's Value Set and Code
+ * values are both null.
+ *
+ * Based on the QMIG, the dataRequirement list should be a unique list of all retrieves with or without
+ * value set or DRC.
+ */
 public class ExportResultParser {
     private static final Log LOGGER = LogFactory.getLog(ExportResultParser.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -70,19 +82,19 @@ public class ExportResultParser {
             return;
         }
 
-        if (isTargetValid(typeNode)) {
+        if (isTargetValid(node)) {
             results.add(typeNode.asText());
         } else {
-            LOGGER.debug("ValueSet node found, not creating entry");
+            LOGGER.debug("ValueSet/Code node found, not creating entry");
         }
     }
 
-    private boolean isTargetValid(JsonNode typeNode) {
-        JsonNode codeFilter = typeNode.get("codeFilter");
+    private boolean isTargetValid(JsonNode node) {
+        JsonNode codeFilter = node.get("codeFilter");
 
         //JsonNode pathFilterNode = null; -- what to do with path do we care
 
-        return codeFilter == null || codeFilter.get("valueSet") == null;
+        return codeFilter == null || codeFilter.size() < 1 || (codeFilter.get(0).get("valueSet") == null && codeFilter.get(0).get("code") == null);
     }
 }
 


### PR DESCRIPTION
### MAT-2731: Fix FHIR Data Requirements in Human Readable

- Check for DRC in dataRequirement codeFilter during filtering
- Renamed variables related to HR generation
## Description
Based on the QMIG, the dataRequirement list should be a unique list of all retrieves with or
without Value Set or Direct Reference Code (DRC).

Update the processor to check for Data Requirements that do not have a DRC and to handle
Data Requirements that do not have a CodeFilter.

Update related variables to better reflect the use case.
## JIRA Ticket
[MAT-2731](https://jira.cms.gov/browse/MAT-2731)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)

**Incorrect HR: Retrieve types are `null`**
![image-2021-02-22-11-28-12-100](https://user-images.githubusercontent.com/56264529/109209651-ca142c80-7779-11eb-920a-1d86bb2dd66e.png)

**Corrected HR with `null`s replaced with Observation/ServiceRequest as appropriate**
![Screen Shot 2021-02-25 at 2 55 44 PM](https://user-images.githubusercontent.com/56264529/109210050-4c045580-777a-11eb-96e6-3f156b8fe274.png)
