### PR TITLE
[MAT-2758] Split up New Measure Name options into separate checkboxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,11 +43,11 @@ war/WEB-INF/jetty-env.xml
 
 /temp/
 
-/mat_cypress/.idea/
-/mat_cypress/cypress/screenshots/
-/mat_cypress/cypress/videos/
-/mat_cypress/node_modules/
-/mat_cypress/*_env.sh
-/mat_cypress/mochawesome-report/
-/mat_cypress/cypress/results/
+/mat-cypress/.idea/
+/mat-cypress/cypress/screenshots/
+/mat-cypress/cypress/videos/
+mat-cypress/node_modules/*
+/mat-cypress/*_env.sh
+/mat-cypress/mochawesome-report/
+/mat-cypress/cypress/results/
 **/.DS_Store

--- a/mat-cypress/cypress/integration/measures/NewMeasureOptions.spec.js
+++ b/mat-cypress/cypress/integration/measures/NewMeasureOptions.spec.js
@@ -2,25 +2,25 @@ import * as newMeasurePage from '../../../elements/CreateNewMeasureElements';
 import * as measureLibrary from '../../../elements/MeasureLibraryElements';
 import * as helper from '../../support/helpers';
 
-describe('New Measure: Field Rules and Validation', () => {
-    beforeEach(function () {
-      cy.get(measureLibrary.newMeasureButton).click();
-      cy.wait(1000);
-    });
+describe('New Measure: CQL Library Name Options', () => {
+  beforeEach(() => {
+    cy.get(measureLibrary.newMeasureButton).click();
+    cy.wait(1000);
+  });
 
-    afterEach(() => {
-      cy.get(newMeasurePage.cancelBtn).click();
-      cy.wait(1000);
-    });
+  afterEach(() => {
+    cy.get(newMeasurePage.cancelBtn).click();
+    cy.wait(1000);
+  });
 
-    before(function () {
-      cy.fixture('mat').then(function (data) {
-        cy.loadCredentials(data).then(() => {
-          cy.matLogin(data.userName, data.password);
-          helper.enabledWithTimeout(measureLibrary.newMeasureButton);
-        });
+  before(() => {
+    cy.fixture('mat').then(function (data) {
+      cy.loadCredentials(data).then(() => {
+        cy.matLogin(data.userName, data.password);
+        helper.enabledWithTimeout(measureLibrary.newMeasureButton);
       });
     });
+  });
 
   after(() => {
     cy.matLogout();
@@ -30,6 +30,17 @@ describe('New Measure: Field Rules and Validation', () => {
     cy.get(newMeasurePage.generateCmsIdCheckbox).should('be.enabled');
     cy.get(newMeasurePage.matchLibraryNameCheckbox).should('be.disabled');
     cy.get(newMeasurePage.cqlLibraryName).should('be.enabled');
+  });
+
+  it('adjusts the label based on Measure Type', () => {
+    cy.get(newMeasurePage.generateCmsIdCheckbox).should('be.enabled');
+    cy.get(newMeasurePage.modelradioFHIR).click();
+    cy.get(newMeasurePage.generateCmsIdCheckboxLabel).should('contain','CMS ID');
+    cy.get(newMeasurePage.generateCmsIdCheckboxLabel).should('not.contain','eCQM ID');
+
+    cy.get(newMeasurePage.modelradioQDM).click();
+    cy.get(newMeasurePage.generateCmsIdCheckboxLabel).should('not.contain', 'CMS ID');
+    cy.get(newMeasurePage.generateCmsIdCheckboxLabel).should('contain', 'eCQM ID');
   });
 
   it('enables the Match CQL Library Name checkbox when Generate ID checkbox is checked', () => {
@@ -65,7 +76,7 @@ describe('New Measure: Field Rules and Validation', () => {
     cy.get(newMeasurePage.cqlLibraryName).should('not.have.value');
   });
 
-  it('defaults on each new measure', () => {
+  it('uses defaults on each new measure', () => {
     cy.get(newMeasurePage.generateCmsIdCheckbox).should('be.enabled');
     cy.get(newMeasurePage.matchLibraryNameCheckbox).should('be.disabled');
     cy.get(newMeasurePage.cqlLibraryName).should('be.enabled');
@@ -83,3 +94,33 @@ describe('New Measure: Field Rules and Validation', () => {
     cy.get(newMeasurePage.cqlLibraryName).should('be.enabled');
   });
 });
+
+// describe('New Measure: Generate CMS/eCQM ID', () => {
+//   before(function () {
+//     cy.fixture('mat').then(function (data) {
+//       cy.loadCredentials(data).then(() => {
+//         cy.matLogin(data.userName, data.password);
+//         helper.enabledWithTimeout(measureLibrary.newMeasureButton);
+//       });
+//     });
+//   });
+
+//   after(() => {
+//     cy.matLogout();
+//   });
+
+//   it('generates a CMS ID for FHIR Measures when the option is selected', () => {
+//     const measureLibPage = new MeasureLibPage();
+
+//     const measureName = measureCreater.createDraftMeasure('Test', 'FHIR', true);
+
+//     measureLibPage.searchInputBox().should('be.enabled');
+//     helper.enterTextConfirmCypress(measureLibPage.searchInputBox(), cqlMeasureName);
+//     measureLibPage.searchButton().click();
+
+//     cy.spinnerNotVisible();
+//     cy.wait(5000);
+
+//   });
+
+// });

--- a/mat-cypress/cypress/integration/measures/NewMeasureOptions.spec.js
+++ b/mat-cypress/cypress/integration/measures/NewMeasureOptions.spec.js
@@ -35,8 +35,8 @@ describe('New Measure: CQL Library Name Options', () => {
   it('adjusts the label based on Measure Type', () => {
     cy.get(newMeasurePage.generateCmsIdCheckbox).should('be.enabled');
     cy.get(newMeasurePage.modelradioFHIR).click();
-    cy.get(newMeasurePage.generateCmsIdCheckboxLabel).should('contain','CMS ID');
-    cy.get(newMeasurePage.generateCmsIdCheckboxLabel).should('not.contain','eCQM ID');
+    cy.get(newMeasurePage.generateCmsIdCheckboxLabel).should('contain', 'CMS ID');
+    cy.get(newMeasurePage.generateCmsIdCheckboxLabel).should('not.contain', 'eCQM ID');
 
     cy.get(newMeasurePage.modelradioQDM).click();
     cy.get(newMeasurePage.generateCmsIdCheckboxLabel).should('not.contain', 'CMS ID');
@@ -49,7 +49,7 @@ describe('New Measure: CQL Library Name Options', () => {
     cy.get(newMeasurePage.cqlLibraryName).should('be.enabled');
 
     cy.get(newMeasurePage.generateCmsIdCheckbox).uncheck();
-    cy.get(newMeasurePage.matchLibraryNameCheckbox).should('be.disabled')
+    cy.get(newMeasurePage.matchLibraryNameCheckbox).should('be.disabled');
     cy.get(newMeasurePage.cqlLibraryName).should('be.enabled');
   });
 
@@ -76,6 +76,18 @@ describe('New Measure: CQL Library Name Options', () => {
     cy.get(newMeasurePage.cqlLibraryName).should('not.have.value');
   });
 
+  it('clears the Match CQL Library Name checkbox when Generate ID checkbox is unchecked', () => {
+    cy.get(newMeasurePage.generateCmsIdCheckbox).check();
+    cy.get(newMeasurePage.matchLibraryNameCheckbox).should('be.enabled');
+
+    cy.get(newMeasurePage.matchLibraryNameCheckbox).check();
+    cy.get(newMeasurePage.cqlLibraryName).should('be.disabled');
+
+    cy.get(newMeasurePage.generateCmsIdCheckbox).uncheck();
+    cy.get(newMeasurePage.matchLibraryNameCheckbox).should('have.value', 'on');
+    cy.get(newMeasurePage.cqlLibraryName).should('be.enabled');
+  });
+
   it('uses defaults on each new measure', () => {
     cy.get(newMeasurePage.generateCmsIdCheckbox).should('be.enabled');
     cy.get(newMeasurePage.matchLibraryNameCheckbox).should('be.disabled');
@@ -94,33 +106,3 @@ describe('New Measure: CQL Library Name Options', () => {
     cy.get(newMeasurePage.cqlLibraryName).should('be.enabled');
   });
 });
-
-// describe('New Measure: Generate CMS/eCQM ID', () => {
-//   before(function () {
-//     cy.fixture('mat').then(function (data) {
-//       cy.loadCredentials(data).then(() => {
-//         cy.matLogin(data.userName, data.password);
-//         helper.enabledWithTimeout(measureLibrary.newMeasureButton);
-//       });
-//     });
-//   });
-
-//   after(() => {
-//     cy.matLogout();
-//   });
-
-//   it('generates a CMS ID for FHIR Measures when the option is selected', () => {
-//     const measureLibPage = new MeasureLibPage();
-
-//     const measureName = measureCreater.createDraftMeasure('Test', 'FHIR', true);
-
-//     measureLibPage.searchInputBox().should('be.enabled');
-//     helper.enterTextConfirmCypress(measureLibPage.searchInputBox(), cqlMeasureName);
-//     measureLibPage.searchButton().click();
-
-//     cy.spinnerNotVisible();
-//     cy.wait(5000);
-
-//   });
-
-// });

--- a/mat-cypress/cypress/integration/measures/NewMeasureOptions.spec.js
+++ b/mat-cypress/cypress/integration/measures/NewMeasureOptions.spec.js
@@ -1,0 +1,85 @@
+import * as newMeasurePage from '../../../elements/CreateNewMeasureElements';
+import * as measureLibrary from '../../../elements/MeasureLibraryElements';
+import * as helper from '../../support/helpers';
+
+describe('New Measure: Field Rules and Validation', () => {
+    beforeEach(function () {
+      cy.get(measureLibrary.newMeasureButton).click();
+      cy.wait(1000);
+    });
+
+    afterEach(() => {
+      cy.get(newMeasurePage.cancelBtn).click();
+      cy.wait(1000);
+    });
+
+    before(function () {
+      cy.fixture('mat').then(function (data) {
+        cy.loadCredentials(data).then(() => {
+          cy.matLogin(data.userName, data.password);
+          helper.enabledWithTimeout(measureLibrary.newMeasureButton);
+        });
+      });
+    });
+
+  after(() => {
+    cy.matLogout();
+  });
+
+  it('has default state', () => {
+    cy.get(newMeasurePage.generateCmsIdCheckbox).should('be.enabled');
+    cy.get(newMeasurePage.matchLibraryNameCheckbox).should('be.disabled');
+    cy.get(newMeasurePage.cqlLibraryName).should('be.enabled');
+  });
+
+  it('enables the Match CQL Library Name checkbox when Generate ID checkbox is checked', () => {
+    cy.get(newMeasurePage.generateCmsIdCheckbox).check();
+    cy.get(newMeasurePage.matchLibraryNameCheckbox).should('be.enabled');
+    cy.get(newMeasurePage.cqlLibraryName).should('be.enabled');
+
+    cy.get(newMeasurePage.generateCmsIdCheckbox).uncheck();
+    cy.get(newMeasurePage.matchLibraryNameCheckbox).should('be.disabled')
+    cy.get(newMeasurePage.cqlLibraryName).should('be.enabled');
+  });
+
+  it('disables and clears the CQL Library Name text box when the Match CQL Library Name Checkbox is checked', () => {
+    cy.get(newMeasurePage.generateCmsIdCheckbox).check();
+    cy.get(newMeasurePage.matchLibraryNameCheckbox).should('be.enabled');
+    cy.get(newMeasurePage.cqlLibraryName).should('be.enabled');
+
+    cy.get(newMeasurePage.matchLibraryNameCheckbox).check();
+    cy.get(newMeasurePage.cqlLibraryName).should('be.disabled');
+
+    cy.get(newMeasurePage.matchLibraryNameCheckbox).uncheck();
+    cy.get(newMeasurePage.cqlLibraryName).should('be.enabled');
+    cy.get(newMeasurePage.cqlLibraryName).type('ValidLibraryName');
+    cy.get(newMeasurePage.cqlLibraryName).blur();
+    cy.get(newMeasurePage.cqlLibraryName).should('have.value', 'ValidLibraryName');
+
+    cy.get(newMeasurePage.matchLibraryNameCheckbox).check();
+    cy.get(newMeasurePage.cqlLibraryName).should('be.disabled');
+    cy.get(newMeasurePage.cqlLibraryName).should('not.have.value');
+
+    cy.get(newMeasurePage.matchLibraryNameCheckbox).uncheck();
+    cy.get(newMeasurePage.cqlLibraryName).should('be.enabled');
+    cy.get(newMeasurePage.cqlLibraryName).should('not.have.value');
+  });
+
+  it('defaults on each new measure', () => {
+    cy.get(newMeasurePage.generateCmsIdCheckbox).should('be.enabled');
+    cy.get(newMeasurePage.matchLibraryNameCheckbox).should('be.disabled');
+    cy.get(newMeasurePage.cqlLibraryName).should('be.enabled');
+
+    cy.get(newMeasurePage.generateCmsIdCheckbox).check();
+    cy.get(newMeasurePage.matchLibraryNameCheckbox).check();
+
+    cy.get(newMeasurePage.cancelBtn).click();
+    cy.wait(1000);
+    cy.get(measureLibrary.newMeasureButton).click();
+    cy.wait(1000);
+
+    cy.get(newMeasurePage.generateCmsIdCheckbox).should('be.enabled');
+    cy.get(newMeasurePage.matchLibraryNameCheckbox).should('be.disabled');
+    cy.get(newMeasurePage.cqlLibraryName).should('be.enabled');
+  });
+});

--- a/mat-cypress/cypress/support/MAT/MeasureAndCQLLibraryCreation.js
+++ b/mat-cypress/cypress/support/MAT/MeasureAndCQLLibraryCreation.js
@@ -1,22 +1,22 @@
-import * as helper from '../helpers';
-import * as measureLibraryElements from '../../../elements/MeasureLibraryElements';
-import * as newMeasureElements from '../../../elements/CreateNewMeasureElements';
-import * as measureComposerElements from '../../../elements/MeasureComposerElements';
+import * as cqlComposerElements from '../../../elements/CQLComposerElements';
 import * as cqlLibraryElements from '../../../elements/CqlLibraryElements';
 import * as createNewCqlLibrary from '../../../elements/CreateNewCQLLibraryElements';
-import * as cqlComposerElements from '../../../elements/CQLComposerElements';
+import * as newMeasureElements from '../../../elements/CreateNewMeasureElements';
+import * as measureComposerElements from '../../../elements/MeasureComposerElements';
 import * as measureDetailsEleemnts from '../../../elements/MeasureDetailsElements';
+import * as measureLibraryElements from '../../../elements/MeasureLibraryElements';
+import * as helper from '../helpers';
 import * as gridRowActions from './GridRowActions';
 
 const draftMeasure = 'DraftMeasure';
 
-export const createDraftMeasure = (measure, model) => {
+export const createDraftMeasure = (measureName, model = 'QDM', generateCmsId = false, matchLibraryName = false) => {
     let name = '';
 
-    if (!measure) {
+    if (!measureName) {
         name = draftMeasure + Date.now();
     } else {
-        name = measure + Date.now();
+        name = measureName + Date.now();
     }
 
     // creating new measure
@@ -25,10 +25,17 @@ export const createDraftMeasure = (measure, model) => {
 
     cy.get(newMeasureElements.measureName).type(name, {delay: 50});
 
-    if (!model || model === 'QDM') {
+    if (model === 'QDM') {
         cy.get(newMeasureElements.modelradioQDM).click();
     } else {
         cy.get(newMeasureElements.modelradioFHIR).click();
+    }
+
+    if(generateCmsId) {
+      cy.get(newMeasureElements.generateCmsIdCheckbox).click();
+      if (matchLibraryName) {
+        cy.get(newMeasureElements.matchLibraryNameCheckbox).click();
+      }
     }
 
     cy.get(newMeasureElements.cqlLibraryName).type(name, {delay: 50});

--- a/mat-cypress/cypress/support/index.js
+++ b/mat-cypress/cypress/support/index.js
@@ -15,9 +15,19 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands';
-
-import './loginCommands';
 import './CqlLibraryGridCommands';
-
-
+import './loginCommands';
 import './measureCommands';
+
+
+
+
+Cypress.Cookies.defaults({
+  preserve: (cookie) => {
+    // implement your own logic here
+    // if the function returns truthy
+    // then the cookie will not be cleared
+    // before each test runs
+    return true;
+  }
+})

--- a/mat-cypress/cypress/support/index.js
+++ b/mat-cypress/cypress/support/index.js
@@ -25,6 +25,6 @@ Cypress.Cookies.defaults({
     // if the function returns truthy
     // then the cookie will not be cleared
     // before each test runs
-    return true;
+    return cookie;
   }
-})
+});

--- a/mat-cypress/elements/CreateNewMeasureElements.js
+++ b/mat-cypress/elements/CreateNewMeasureElements.js
@@ -2,6 +2,7 @@ export const measureName = '#MeasureNameTextArea';
 export const modelradioFHIR = '#gwt-uid-3';
 export const modelradioQDM = '#gwt-uid-4';
 export const generateCmsIdCheckbox = '#generateCmsId_Input';
+export const generateCmsIdCheckboxLabel = '#generateCmsId_CheckBox > label > span';
 export const matchLibraryNameCheckbox = '#matchLibName_Input';
 export const cqlLibraryName = '#CqlLibraryNameTextArea';
 export const shortName = '#ShortNameTextBox';

--- a/mat-cypress/elements/CreateNewMeasureElements.js
+++ b/mat-cypress/elements/CreateNewMeasureElements.js
@@ -1,6 +1,8 @@
 export const measureName = '#MeasureNameTextArea';
 export const modelradioFHIR = '#gwt-uid-3';
 export const modelradioQDM = '#gwt-uid-4';
+export const generateCmsIdCheckbox = '#generateCmsId_Input';
+export const matchLibraryNameCheckbox = '#matchLibName_Input';
 export const cqlLibraryName = '#CqlLibraryNameTextArea';
 export const shortName = '#ShortNameTextBox';
 export const measureScoringListBox = '#measScoringInput_ListBoxMVP';

--- a/mat-cypress/package.json
+++ b/mat-cypress/package.json
@@ -13,6 +13,11 @@
   "devDependencies": {
     "cypress": "^6.5.0",
     "cypress-multi-reporters": "^1.4.0",
+    "eslint": "^7.21.0",
+    "eslint-config-standard": "^16.0.2",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^4.3.1",
     "mocha": "^8.3.0",
     "mochawesome": "^6.2.1",
     "mochawesome-merge": "^4.2.0",

--- a/src/main/java/mat/client/measure/AbstractNewMeasureView.java
+++ b/src/main/java/mat/client/measure/AbstractNewMeasureView.java
@@ -409,16 +409,18 @@ public class AbstractNewMeasureView implements DetailDisplay {
         cqlLibraryNameTextBox.setWidth("400px");
         cqlLibraryNameTextBox.setHeight("50px");
         cqlLibraryNameTextBox.setMaxLength(500);
-        cqlLibraryNameTextBox.addBlurHandler(errorHandler.buildBlurHandler(cqlLibraryNameTextBox,
-                (s) -> {
-                    String result = null;
-                    if (fhirModel.getValue()) {
-                        result = getFirst(CommonMeasureValidator.validateFhirLibraryName(s));
-                    } else {
-                        result = getFirst(CommonMeasureValidator.validateQDMName(s));
+        cqlLibraryNameTextBox.addBlurHandler(
+            errorHandler.buildBlurHandler(cqlLibraryNameTextBox,
+                (value) -> {
+                    if (cqlLibraryNameTextBox.isEnabled()) {
+                        if (fhirModel.getValue()) {
+                            return getFirst(CommonMeasureValidator.validateFhirLibraryName(value));
+                        }
+                        return getFirst(CommonMeasureValidator.validateQDMName(value));
                     }
-                    return result;
-                }));
+                    return null;
+            })
+        );
     }
 
     protected HorizontalPanel buildCQLLibraryNamePanel() {

--- a/src/main/java/mat/client/measure/AbstractNewMeasureView.java
+++ b/src/main/java/mat/client/measure/AbstractNewMeasureView.java
@@ -354,20 +354,18 @@ public class AbstractNewMeasureView implements DetailDisplay {
         nameAndIdOptionGroup.add(generateCmsIdCheckbox);
     }
 
-    protected void addMatchLibraryNameToCmsIdCheckbox(){
+    protected void addMatchLibraryNameToCmsIdCheckbox() {
+        // TODO Add cy id for cypress.io testing
         matchLibraryNameToCmsIdCheckbox.setText("Match CQL Library Name to Generated ID.");
         matchLibraryNameToCmsIdCheckbox.setTitle("Click to match CQL Library Name to Generated ID.");
         matchLibraryNameToCmsIdCheckbox.setId("matchLibName_CheckBox");
         matchLibraryNameToCmsIdCheckbox.setEnabled(false);
         matchLibraryNameToCmsIdCheckbox.getElement().getStyle().setMarginTop(2, Style.Unit.PX);
+        matchLibraryNameToCmsIdCheckbox.getElement().getStyle().setMarginLeft(15, Style.Unit.PX);
         ((Element) matchLibraryNameToCmsIdCheckbox.getElement().getChild(0)).setAttribute("for", "matchLibName_Input");
         ((Element) matchLibraryNameToCmsIdCheckbox.getElement().getChild(0).getChild(0)).setAttribute("id", "matchLibName_Input");
 
-        //Indent the checkbox.
-        HTMLPanel subOptions = new HTMLPanel("<ul style=\"list-style:none;padding-left:15px\"><li id=\"match_name\"></li></ul>");
-        subOptions.add(matchLibraryNameToCmsIdCheckbox, "match_name");
-
-        nameAndIdOptionGroup.add(subOptions);
+        nameAndIdOptionGroup.add(matchLibraryNameToCmsIdCheckbox);
     }
 
     protected void buildMeasureNameTextArea() {

--- a/src/main/java/mat/client/measure/AbstractNewMeasureView.java
+++ b/src/main/java/mat/client/measure/AbstractNewMeasureView.java
@@ -87,10 +87,12 @@ public class AbstractNewMeasureView implements DetailDisplay {
     public void clearFields() {
         measureNameTextBox.setText("");
         eCQMAbbreviatedTitleTextBox.setText("");
+        cqlLibraryNameTextBox.setEnabled(true);
         cqlLibraryNameTextBox.setText("");
         measureScoringListBox.setSelectedIndex(0);//default to --Select-- value.
         helpBlock.setText("");
         generateCmsIdCheckbox.setValue(false);
+        matchLibraryNameToCmsIdCheckbox.setEnabled(false);
         matchLibraryNameToCmsIdCheckbox.setValue(false);
         messageFormGrp.setValidationState(ValidationState.NONE);
         getErrorMessageDisplay().clearAlert();

--- a/src/main/java/mat/client/measure/AbstractNewMeasureView.java
+++ b/src/main/java/mat/client/measure/AbstractNewMeasureView.java
@@ -338,6 +338,7 @@ public class AbstractNewMeasureView implements DetailDisplay {
     }
 
     protected void addGenerateCmsIdCheckbox() {
+        // Default label should state 'CMS ID' as long as FHIR is the default model type.
         generateCmsIdCheckbox.setText("Automatically generate a CMS ID on Save.");
         generateCmsIdCheckbox.setTitle("Click to generate a CMS ID on Save.");
         generateCmsIdCheckbox.setId("generateCmsId_CheckBox");
@@ -348,16 +349,17 @@ public class AbstractNewMeasureView implements DetailDisplay {
     }
 
     protected void addCompositeGenerateCmsIdCheckbox() {
+        // Default label should state 'eCQM' since composite measures are QDM only.
         generateCmsIdCheckbox.setText("Automatically generate an eCQM ID on Save.");
         generateCmsIdCheckbox.setTitle("Click to generate an eCQM ID on Save.");
         generateCmsIdCheckbox.setId("generateCmsId_CheckBox");
+        generateCmsIdCheckbox.getElement().getStyle().setMarginBottom(0, Style.Unit.EM);
         ((Element) generateCmsIdCheckbox.getElement().getChild(0)).setAttribute("for", "generateCmsId_Input");
         ((Element) generateCmsIdCheckbox.getElement().getChild(0).getChild(0)).setAttribute("id", "generateCmsId_Input");
         nameAndIdOptionGroup.add(generateCmsIdCheckbox);
     }
 
     protected void addMatchLibraryNameToCmsIdCheckbox() {
-        // TODO Add cy id for cypress.io testing
         matchLibraryNameToCmsIdCheckbox.setText("Match CQL Library Name to Generated ID.");
         matchLibraryNameToCmsIdCheckbox.setTitle("Click to match CQL Library Name to Generated ID.");
         matchLibraryNameToCmsIdCheckbox.setId("matchLibName_CheckBox");

--- a/src/main/java/mat/client/measure/AbstractNewMeasureView.java
+++ b/src/main/java/mat/client/measure/AbstractNewMeasureView.java
@@ -41,7 +41,7 @@ public class AbstractNewMeasureView implements DetailDisplay {
     protected FormGroup messageFormGrp = new FormGroup();
     protected FormGroup measureNameGroup = new FormGroup();
     protected FormGroup measureModelGroup = new FormGroup();
-    protected FormGroup generateCmsIdGroup = new FormGroup();
+    protected FormGroup nameAndIdOptionGroup = new FormGroup();
     protected FormGroup cqlLibraryNameGroup = new FormGroup();
     protected FormGroup shortNameGroup = new FormGroup();
     protected FormGroup scoringGroup = new FormGroup();
@@ -53,6 +53,7 @@ public class AbstractNewMeasureView implements DetailDisplay {
     private ErrorHandler errorHandler = new ErrorHandler();
 
     protected CheckBox generateCmsIdCheckbox = new CheckBox();
+    protected CheckBox matchLibraryNameToCmsIdCheckbox = new CheckBox();
 
     public static final String CAUTION_LIBRARY_NAME_MSG_STR = "<div style=\"padding-left:5px;\">WARNING: Long CQL Library names may cause problems upon export with zip files and file storage. "
             + "Please keep CQL Library names concise.<br/>";
@@ -218,6 +219,11 @@ public class AbstractNewMeasureView implements DetailDisplay {
     }
 
     @Override
+    public CheckBox getMatchLibraryNameToCmsIdCheckbox() {
+        return matchLibraryNameToCmsIdCheckbox;
+    }
+
+    @Override
     public RadioButton getFhirModel() {
         return fhirModel;
     }
@@ -323,24 +329,32 @@ public class AbstractNewMeasureView implements DetailDisplay {
     }
 
     protected void addGenerateCmsIdCheckbox() {
-        generateCmsIdCheckbox.setText("Automatically generate a CMS ID and matching Library Name.");
-        generateCmsIdCheckbox.setTitle("Click to generate a CMS ID and matching Library Name.");
+        generateCmsIdCheckbox.setText("Automatically generate a CMS ID on Save.");
+        generateCmsIdCheckbox.setTitle("Click to generate a CMS ID on Save.");
         generateCmsIdCheckbox.setId("generateCmsId_CheckBox");
         ((Element) generateCmsIdCheckbox.getElement().getChild(0)).setAttribute("for", "generateCmsId_Input");
         ((Element) generateCmsIdCheckbox.getElement().getChild(0).getChild(0)).setAttribute("id", "generateCmsId_Input");
-        generateCmsIdGroup.add(generateCmsIdCheckbox);
+        nameAndIdOptionGroup.add(generateCmsIdCheckbox);
     }
 
     protected void addCompositeGenerateCmsIdCheckbox() {
-        generateCmsIdCheckbox.setText("Automatically generate an eCQM ID and matching Library Name.");
-        generateCmsIdCheckbox.setTitle("Click to generate an eCQM ID and matching Library Name.");
+        generateCmsIdCheckbox.setText("Automatically generate an eCQM ID on Save.");
+        generateCmsIdCheckbox.setTitle("Click to generate an eCQM ID on Save.");
         generateCmsIdCheckbox.setId("generateCmsId_CheckBox");
         ((Element) generateCmsIdCheckbox.getElement().getChild(0)).setAttribute("for", "generateCmsId_Input");
         ((Element) generateCmsIdCheckbox.getElement().getChild(0).getChild(0)).setAttribute("id", "generateCmsId_Input");
-        generateCmsIdGroup.add(generateCmsIdCheckbox);
+        nameAndIdOptionGroup.add(generateCmsIdCheckbox);
     }
 
-
+    protected void addMatchLibraryNameToCmsIdCheckbox(){
+        matchLibraryNameToCmsIdCheckbox.setText("Match CQL Library Name to Generated ID.");
+        matchLibraryNameToCmsIdCheckbox.setTitle("Click to match CQL Library Name to Generated ID.");
+        matchLibraryNameToCmsIdCheckbox.setId("matchLibName_CheckBox");
+        matchLibraryNameToCmsIdCheckbox.setEnabled(false);
+        ((Element) matchLibraryNameToCmsIdCheckbox.getElement().getChild(0)).setAttribute("for", "matchLibName_Input");
+        ((Element) matchLibraryNameToCmsIdCheckbox.getElement().getChild(0).getChild(0)).setAttribute("id", "matchLibName_Input");
+        nameAndIdOptionGroup.add(matchLibraryNameToCmsIdCheckbox);
+    }
 
     protected void buildMeasureNameTextArea() {
         measureNameTextBox.setId("MeasureNameTextArea");
@@ -483,7 +497,7 @@ public class AbstractNewMeasureView implements DetailDisplay {
         FieldSet formFieldSet = new FieldSet();
         formFieldSet.add(measureNameGroup);
         formFieldSet.add(measureModelGroup);
-        formFieldSet.add(generateCmsIdGroup);
+        formFieldSet.add(nameAndIdOptionGroup);
         formFieldSet.add(cqlLibraryNameGroup);
         formFieldSet.add(shortNameGroup);
         formFieldSet.add(scoringGroup);

--- a/src/main/java/mat/client/measure/AbstractNewMeasureView.java
+++ b/src/main/java/mat/client/measure/AbstractNewMeasureView.java
@@ -1,6 +1,7 @@
 package mat.client.measure;
 
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.dom.client.HasClickHandlers;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.RadioButton;
@@ -90,6 +91,7 @@ public class AbstractNewMeasureView implements DetailDisplay {
         measureScoringListBox.setSelectedIndex(0);//default to --Select-- value.
         helpBlock.setText("");
         generateCmsIdCheckbox.setValue(false);
+        matchLibraryNameToCmsIdCheckbox.setValue(false);
         messageFormGrp.setValidationState(ValidationState.NONE);
         getErrorMessageDisplay().clearAlert();
         warningMessageAlert.clearAlert();
@@ -337,6 +339,7 @@ public class AbstractNewMeasureView implements DetailDisplay {
         generateCmsIdCheckbox.setText("Automatically generate a CMS ID on Save.");
         generateCmsIdCheckbox.setTitle("Click to generate a CMS ID on Save.");
         generateCmsIdCheckbox.setId("generateCmsId_CheckBox");
+        generateCmsIdCheckbox.getElement().getStyle().setMarginBottom(0, Style.Unit.EM);
         ((Element) generateCmsIdCheckbox.getElement().getChild(0)).setAttribute("for", "generateCmsId_Input");
         ((Element) generateCmsIdCheckbox.getElement().getChild(0).getChild(0)).setAttribute("id", "generateCmsId_Input");
         nameAndIdOptionGroup.add(generateCmsIdCheckbox);
@@ -356,9 +359,15 @@ public class AbstractNewMeasureView implements DetailDisplay {
         matchLibraryNameToCmsIdCheckbox.setTitle("Click to match CQL Library Name to Generated ID.");
         matchLibraryNameToCmsIdCheckbox.setId("matchLibName_CheckBox");
         matchLibraryNameToCmsIdCheckbox.setEnabled(false);
+        matchLibraryNameToCmsIdCheckbox.getElement().getStyle().setMarginTop(2, Style.Unit.PX);
         ((Element) matchLibraryNameToCmsIdCheckbox.getElement().getChild(0)).setAttribute("for", "matchLibName_Input");
         ((Element) matchLibraryNameToCmsIdCheckbox.getElement().getChild(0).getChild(0)).setAttribute("id", "matchLibName_Input");
-        nameAndIdOptionGroup.add(matchLibraryNameToCmsIdCheckbox);
+
+        //Indent the checkbox.
+        HTMLPanel subOptions = new HTMLPanel("<ul style=\"list-style:none;padding-left:15px\"><li id=\"match_name\"></li></ul>");
+        subOptions.add(matchLibraryNameToCmsIdCheckbox, "match_name");
+
+        nameAndIdOptionGroup.add(subOptions);
     }
 
     protected void buildMeasureNameTextArea() {

--- a/src/main/java/mat/client/measure/AbstractNewMeasureView.java
+++ b/src/main/java/mat/client/measure/AbstractNewMeasureView.java
@@ -152,7 +152,12 @@ public class AbstractNewMeasureView implements DetailDisplay {
     }
 
     @Override
-    public HasValue<String> getCQLLibraryNameTextBox() {
+    public HasValue<String> getCQLLibraryNameTextBoxValue() {
+        return cqlLibraryNameTextBox;
+    }
+
+    @Override
+    public TextArea getCQLLibraryNameTextBox() {
         return cqlLibraryNameTextBox;
     }
 

--- a/src/main/java/mat/client/measure/AbstractNewMeasureView.java
+++ b/src/main/java/mat/client/measure/AbstractNewMeasureView.java
@@ -339,8 +339,8 @@ public class AbstractNewMeasureView implements DetailDisplay {
 
     protected void addGenerateCmsIdCheckbox() {
         // Default label should state 'CMS ID' as long as FHIR is the default model type.
-        generateCmsIdCheckbox.setText("Automatically generate a CMS ID on Save.");
-        generateCmsIdCheckbox.setTitle("Click to generate a CMS ID on Save.");
+        generateCmsIdCheckbox.setText("Automatically Generate a CMS ID on Save.");
+        generateCmsIdCheckbox.setTitle("Click to enerate a CMS ID on Save.");
         generateCmsIdCheckbox.setId("generateCmsId_CheckBox");
         generateCmsIdCheckbox.getElement().getStyle().setMarginBottom(0, Style.Unit.EM);
         ((Element) generateCmsIdCheckbox.getElement().getChild(0)).setAttribute("for", "generateCmsId_Input");
@@ -350,7 +350,7 @@ public class AbstractNewMeasureView implements DetailDisplay {
 
     protected void addCompositeGenerateCmsIdCheckbox() {
         // Default label should state 'eCQM' since composite measures are QDM only.
-        generateCmsIdCheckbox.setText("Automatically generate an eCQM ID on Save.");
+        generateCmsIdCheckbox.setText("Automatically Generate an eCQM ID on Save.");
         generateCmsIdCheckbox.setTitle("Click to generate an eCQM ID on Save.");
         generateCmsIdCheckbox.setId("generateCmsId_CheckBox");
         generateCmsIdCheckbox.getElement().getStyle().setMarginBottom(0, Style.Unit.EM);

--- a/src/main/java/mat/client/measure/DetailDisplay.java
+++ b/src/main/java/mat/client/measure/DetailDisplay.java
@@ -11,6 +11,7 @@ import mat.client.validator.ErrorHandler;
 import org.gwtbootstrap3.client.ui.CheckBox;
 import org.gwtbootstrap3.client.ui.FormGroup;
 import org.gwtbootstrap3.client.ui.HelpBlock;
+import org.gwtbootstrap3.client.ui.TextArea;
 
 import java.util.List;
 
@@ -29,7 +30,9 @@ public interface DetailDisplay extends BaseDisplay {
 
 	HasValue<String> getMeasureNameTextBox();
 	
-	HasValue<String> getCQLLibraryNameTextBox();
+	HasValue<String> getCQLLibraryNameTextBoxValue();
+
+	TextArea getCQLLibraryNameTextBox();
 
 	HasClickHandlers getSaveButton();
 

--- a/src/main/java/mat/client/measure/DetailDisplay.java
+++ b/src/main/java/mat/client/measure/DetailDisplay.java
@@ -59,6 +59,8 @@ public interface DetailDisplay extends BaseDisplay {
 
     CheckBox getGenerateCmsIdCheckbox();
 
+    CheckBox getMatchLibraryNameToCmsIdCheckbox();
+
     RadioButton getFhirModel();
 
     RadioButton getQdmModel();

--- a/src/main/java/mat/client/measure/ManageMeasurePresenter.java
+++ b/src/main/java/mat/client/measure/ManageMeasurePresenter.java
@@ -967,6 +967,7 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
         warningConfirmationMessageAlert = detailDisplay.getWarningConfirmationMessageAlert();
         currentDetails = new ManageMeasureDetailModel();
         detailDisplay.showCautionMsg(false);
+        showOptionCheckboxes();
         displayCommonDetailForAdd(detailDisplay);
         panel.setHeading("My Measures > Create New Measure", MEASURE_LIBRARY);
         setDetailsToView();
@@ -990,6 +991,7 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
         Mat.focusSkipLists(MEASURE_LIBRARY);
         detailDisplay.showMeasureName(true);
         detailDisplay.showCautionMsg(true);
+        hideOptionCheckboxes();
         setDetailsToView();
 
         detailDisplay.getMeasureNameTextBox().setValue("");
@@ -1007,15 +1009,27 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
         Mat.focusSkipLists(MEASURE_LIBRARY);
         detailDisplay.showCautionMsg(true);
         detailDisplay.showMeasureName(true);
+        hideOptionCheckboxes();
         setDetailsToView();
         updateSaveButtonClickHandler(event -> draftMeasure());
         panel.setContent(detailDisplay.asWidget());
+    }
+
+    private void hideOptionCheckboxes() {
+        MatContext.get().setVisible(detailDisplay.getGenerateCmsIdCheckbox(), false);
+        MatContext.get().setVisible(detailDisplay.getMatchLibraryNameToCmsIdCheckbox(), false);
+    }
+
+    private void showOptionCheckboxes() {
+        MatContext.get().setVisible(detailDisplay.getGenerateCmsIdCheckbox(), true);
+        MatContext.get().setVisible(detailDisplay.getMatchLibraryNameToCmsIdCheckbox(), true);
     }
 
     private void displayNewCompositeMeasureWidget() {
         clearErrorMessageAlerts();
         warningConfirmationMessageAlert = compositeDetailDisplay.getWarningConfirmationMessageAlert();
         displayCommonDetailForAdd(compositeDetailDisplay);
+        showOptionCheckboxes();
         panel.setHeading("My Measures > Create New Composite Measure", COMPOSITE_MEASURE);
         setCompositeDetailsToView();
         Mat.focusSkipLists(COMPOSITE_MEASURE);

--- a/src/main/java/mat/client/measure/ManageMeasurePresenter.java
+++ b/src/main/java/mat/client/measure/ManageMeasurePresenter.java
@@ -610,8 +610,9 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
         });
         detailDisplay.getGenerateCmsIdCheckbox().addValueChangeHandler(clickEvent -> {
             detailDisplay.getMatchLibraryNameToCmsIdCheckbox().setEnabled(clickEvent.getValue());
-            if (clickEvent.getValue()) {
+            if (!clickEvent.getValue()) {
                 detailDisplay.getMatchLibraryNameToCmsIdCheckbox().setValue(false);
+                detailDisplay.getCQLLibraryNameTextBox().setEnabled(true);
             }
         });
         detailDisplay.getMatchLibraryNameToCmsIdCheckbox().addValueChangeHandler(clickEvent -> {

--- a/src/main/java/mat/client/measure/ManageMeasurePresenter.java
+++ b/src/main/java/mat/client/measure/ManageMeasurePresenter.java
@@ -472,7 +472,7 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
 
         ((NewCompositeMeasureView) compositeDetailDisplay).getMeasureNameTextBox().addValueChangeHandler(event -> setIsPageDirty(true));
         ((NewCompositeMeasureView) compositeDetailDisplay).getECQMAbbreviatedTitleTextBox().addValueChangeHandler(event -> setIsPageDirty(true));
-        ((NewCompositeMeasureView) compositeDetailDisplay).getCQLLibraryNameTextBox().addValueChangeHandler(event -> setIsPageDirty(true));
+        ((NewCompositeMeasureView) compositeDetailDisplay).getCQLLibraryNameTextBoxValue().addValueChangeHandler(event -> setIsPageDirty(true));
         ((NewCompositeMeasureView) compositeDetailDisplay).getMeasureScoringListBox().addValueChangeHandler(event -> setIsPageDirty(true));
         ((NewCompositeMeasureView) compositeDetailDisplay).getPatientBasedListBox().addValueChangeHandler(event -> setIsPageDirty(true));
         ((NewCompositeMeasureView) compositeDetailDisplay).getCompositeScoringListBox().addChangeHandler(event -> setIsPageDirty(true));
@@ -483,7 +483,7 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
             if (clickEvent.getValue()) {
                 generateCompositeCmsIdAndSetLibraryName();
             } else {
-                compositeDetailDisplay.getCQLLibraryNameTextBox().setValue("");
+                compositeDetailDisplay.getCQLLibraryNameTextBoxValue().setValue("");
             }
         });
     }
@@ -498,7 +498,7 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
             @Override
             public void onSuccess(Integer integer) {
                 currentCompositeMeasureDetails.seteMeasureId(integer);
-                compositeDetailDisplay.getCQLLibraryNameTextBox().setValue("CMS" + integer);
+                compositeDetailDisplay.getCQLLibraryNameTextBoxValue().setValue("CMS" + integer);
             }
         });
     }
@@ -904,7 +904,7 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
 
         dialogBox.getConfirmButton().addClickHandler(event -> {
             currentDetails.seteMeasureId(result.geteMeasureId());
-            detailDisplay.getCQLLibraryNameTextBox().setValue("CMS" + result.geteMeasureId());
+            detailDisplay.getCQLLibraryNameTextBoxValue().setValue("CMS" + result.geteMeasureId());
             createNewMeasure();
             dialogBox.closeDialogBox();
         });
@@ -997,7 +997,7 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
 
         detailDisplay.getMeasureNameTextBox().setValue("");
         detailDisplay.getECQMAbbreviatedTitleTextBox().setValue("");
-        detailDisplay.getCQLLibraryNameTextBox().setValue("");
+        detailDisplay.getCQLLibraryNameTextBoxValue().setValue("");
         updateSaveButtonClickHandler(event -> cloneMeasure());
         panel.setContent(detailDisplay.asWidget());
     }
@@ -2063,7 +2063,7 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
         resetPatientBasedInput(compositeDetailDisplay);
         compositeDetailDisplay.getMeasureNameTextBox().setValue(currentCompositeMeasureDetails.getMeasureName());
         compositeDetailDisplay.getECQMAbbreviatedTitleTextBox().setValue(currentCompositeMeasureDetails.getShortName());
-        compositeDetailDisplay.getCQLLibraryNameTextBox().setValue(currentCompositeMeasureDetails.getCQLLibraryName());
+        compositeDetailDisplay.getCQLLibraryNameTextBoxValue().setValue(currentCompositeMeasureDetails.getCQLLibraryName());
         ((NewCompositeMeasureView) compositeDetailDisplay).setCompositeScoringSelectedValue(currentCompositeMeasureDetails.getCompositeScoringMethod());
         compositeDetailDisplay.getMeasureScoringListBox().setValueMetadata(currentCompositeMeasureDetails.getMeasScoring());
 
@@ -2086,7 +2086,7 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
         detailDisplay.clearFields();
         resetPatientBasedInput(detailDisplay);
         detailDisplay.getMeasureNameTextBox().setValue(currentDetails.getMeasureName());
-        detailDisplay.getCQLLibraryNameTextBox().setValue(currentDetails.getCQLLibraryName());
+        detailDisplay.getCQLLibraryNameTextBoxValue().setValue(currentDetails.getCQLLibraryName());
         detailDisplay.getECQMAbbreviatedTitleTextBox().setValue(currentDetails.getShortName());
         detailDisplay.getMeasureScoringListBox().setValueMetadata(currentDetails.getMeasScoring());
 
@@ -2274,7 +2274,7 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
         currentDetails.setMeasureName(detailDisplay.getMeasureNameTextBox().getValue().trim());
         currentDetails.setShortName(detailDisplay.getECQMAbbreviatedTitleTextBox().getValue().trim());
         currentDetails.setMeasureModel(detailDisplay.getMeasureModelType());
-        currentDetails.setCQLLibraryName(detailDisplay.getCQLLibraryNameTextBox().getValue().trim());
+        currentDetails.setCQLLibraryName(detailDisplay.getCQLLibraryNameTextBoxValue().getValue().trim());
         String measureScoring = detailDisplay.getMeasureScoringValue();
 
         currentDetails.setMeasScoring(measureScoring);
@@ -2295,7 +2295,7 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
 
     private void updateCompositeDetailsFromCompositeDetailView() {
         currentCompositeMeasureDetails.setMeasureName(compositeDetailDisplay.getMeasureNameTextBox().getValue().trim());
-        currentCompositeMeasureDetails.setCQLLibraryName(compositeDetailDisplay.getCQLLibraryNameTextBox().getValue().trim());
+        currentCompositeMeasureDetails.setCQLLibraryName(compositeDetailDisplay.getCQLLibraryNameTextBoxValue().getValue().trim());
         currentCompositeMeasureDetails.setShortName(compositeDetailDisplay.getECQMAbbreviatedTitleTextBox().getValue().trim());
         currentCompositeMeasureDetails.setCompositeScoringMethod(((NewCompositeMeasureView) compositeDetailDisplay).getCompositeScoringValue());
         String measureScoring = compositeDetailDisplay.getMeasureScoringValue();
@@ -2369,7 +2369,7 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
 
         dialogBox.getConfirmButton().addClickHandler(event -> {
             currentCompositeMeasureDetails.seteMeasureId(result.geteMeasureId());
-            compositeDetailDisplay.getCQLLibraryNameTextBox().setValue("CMS" + result.geteMeasureId());
+            compositeDetailDisplay.getCQLLibraryNameTextBoxValue().setValue("CMS" + result.geteMeasureId());
             createNewCompositeMeasure();
             dialogBox.closeDialogBox();
         });

--- a/src/main/java/mat/client/measure/ManageMeasurePresenter.java
+++ b/src/main/java/mat/client/measure/ManageMeasurePresenter.java
@@ -577,6 +577,7 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
 
         detailDisplay.getMeasureNameTextBox().addValueChangeHandler(event -> setIsPageDirty(true));
         addHandlerToGenerateCmsId();
+        addHandlerToMatchLibraryName();
         detailDisplay.getCQLLibraryNameTextBox().addValueChangeHandler(event -> setIsPageDirty(true));
         detailDisplay.getECQMAbbreviatedTitleTextBox().addValueChangeHandler(event -> setIsPageDirty(true));
 
@@ -599,26 +600,35 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
     private void addHandlerToGenerateCmsId() {
         detailDisplay.getFhirModel().addValueChangeHandler(clickEvent -> {
             if (clickEvent.getValue()) {
-                detailDisplay.getGenerateCmsIdCheckbox().setText("Automatically generate a CMS ID and matching Library Name.");
-                detailDisplay.getGenerateCmsIdCheckbox().setTitle("Click to generate a CMS ID and matching Library Name.");
+                detailDisplay.getGenerateCmsIdCheckbox().setText("Automatically generate a CMS ID on Save.");
+                detailDisplay.getGenerateCmsIdCheckbox().setTitle("Click to generate a CMS ID on Save.");
             }
         });
         detailDisplay.getQdmModel().addValueChangeHandler(clickEvent -> {
             if (clickEvent.getValue()) {
-                detailDisplay.getGenerateCmsIdCheckbox().setText("Automatically generate an eCQM ID and matching Library Name.");
-                detailDisplay.getGenerateCmsIdCheckbox().setTitle("Automatically generate an eCQM ID and matching Library Name.");
+                detailDisplay.getGenerateCmsIdCheckbox().setText("Automatically generate an eCQM ID on Save.");
+                detailDisplay.getGenerateCmsIdCheckbox().setTitle("Automatically generate an eCQM ID on Save.");
             }
         });
         detailDisplay.getGenerateCmsIdCheckbox().addValueChangeHandler(clickEvent -> {
             if (clickEvent.getValue()) {
-                generateCmsIdAndSetLibraryName();
+                generateCmsId();
             } else {
                 detailDisplay.getCQLLibraryNameTextBox().setValue("");
             }
         });
     }
 
-    private void generateCmsIdAndSetLibraryName() {
+    private void addHandlerToMatchLibraryName() {
+        detailDisplay.getGenerateCmsIdCheckbox().addValueChangeHandler(clickEvent -> {
+            detailDisplay.getMatchLibraryNameToCmsIdCheckbox().setEnabled(clickEvent.getValue());
+            if (!clickEvent.getValue()) {
+                detailDisplay.getMatchLibraryNameToCmsIdCheckbox().setValue(false);
+            }
+        });
+    }
+
+    private void generateCmsId() {
         MatContext.get().getMeasureService().generateEmeasureIdForNewMeasure(new AsyncCallback<Integer>() {
             @Override
             public void onFailure(Throwable throwable) {
@@ -628,7 +638,6 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
             @Override
             public void onSuccess(Integer integer) {
                 currentDetails.seteMeasureId(integer);
-                detailDisplay.getCQLLibraryNameTextBox().setValue("CMS" + integer);
             }
         });
     }

--- a/src/main/java/mat/client/measure/ManageMeasurePresenter.java
+++ b/src/main/java/mat/client/measure/ManageMeasurePresenter.java
@@ -598,13 +598,13 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
     private void addCheckboxHandlers(DetailDisplay detailDisplay) {
         detailDisplay.getFhirModel().addValueChangeHandler(clickEvent -> {
             if (clickEvent.getValue()) {
-                detailDisplay.getGenerateCmsIdCheckbox().setText("Automatically generate a CMS ID on Save.");
+                detailDisplay.getGenerateCmsIdCheckbox().setText("Automatically Generate a CMS ID on Save.");
                 detailDisplay.getGenerateCmsIdCheckbox().setTitle("Click to generate a CMS ID on Save.");
             }
         });
         detailDisplay.getQdmModel().addValueChangeHandler(clickEvent -> {
             if (clickEvent.getValue()) {
-                detailDisplay.getGenerateCmsIdCheckbox().setText("Automatically generate an eCQM ID on Save.");
+                detailDisplay.getGenerateCmsIdCheckbox().setText("Automatically Generate an eCQM ID on Save.");
                 detailDisplay.getGenerateCmsIdCheckbox().setTitle("Automatically generate an eCQM ID on Save.");
             }
         });

--- a/src/main/java/mat/client/measure/ManageMeasurePresenter.java
+++ b/src/main/java/mat/client/measure/ManageMeasurePresenter.java
@@ -577,8 +577,7 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
 
         detailDisplay.getMeasureNameTextBox().addValueChangeHandler(event -> setIsPageDirty(true));
         addHandlerToGenerateCmsId();
-        addHandlerToMatchLibraryName();
-        detailDisplay.getCQLLibraryNameTextBox().addValueChangeHandler(event -> setIsPageDirty(true));
+        detailDisplay.getCQLLibraryNameTextBoxValue().addValueChangeHandler(event -> setIsPageDirty(true));
         detailDisplay.getECQMAbbreviatedTitleTextBox().addValueChangeHandler(event -> setIsPageDirty(true));
 
         MatContext.get().getListBoxCodeProvider().getScoringList(new AsyncCallback<List<? extends HasListBox>>() {
@@ -611,19 +610,17 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
             }
         });
         detailDisplay.getGenerateCmsIdCheckbox().addValueChangeHandler(clickEvent -> {
+            detailDisplay.getMatchLibraryNameToCmsIdCheckbox().setEnabled(clickEvent.getValue());
             if (clickEvent.getValue()) {
                 generateCmsId();
-            } else {
-                detailDisplay.getCQLLibraryNameTextBox().setValue("");
+                detailDisplay.getMatchLibraryNameToCmsIdCheckbox().setValue(false);
             }
         });
-    }
-
-    private void addHandlerToMatchLibraryName() {
-        detailDisplay.getGenerateCmsIdCheckbox().addValueChangeHandler(clickEvent -> {
-            detailDisplay.getMatchLibraryNameToCmsIdCheckbox().setEnabled(clickEvent.getValue());
-            if (!clickEvent.getValue()) {
-                detailDisplay.getMatchLibraryNameToCmsIdCheckbox().setValue(false);
+        detailDisplay.getMatchLibraryNameToCmsIdCheckbox().addValueChangeHandler(clickEvent -> {
+            detailDisplay.getCQLLibraryNameTextBox().setEnabled(!clickEvent.getValue());
+            if (clickEvent.getValue()) {
+                detailDisplay.getCQLLibraryNameTextBoxValue().setValue(null);
+                detailDisplay.getErrorHandler().clearErrors(detailDisplay.getCQLLibraryNameTextBox().getElement());
             }
         });
     }

--- a/src/main/java/mat/client/measure/NewCompositeMeasureView.java
+++ b/src/main/java/mat/client/measure/NewCompositeMeasureView.java
@@ -23,201 +23,202 @@ import org.gwtbootstrap3.client.ui.FormLabel;
 import java.util.List;
 
 public class NewCompositeMeasureView extends AbstractNewMeasureView {
-	private String cautionMsgStr = "Caution: The Composite Scoring Method field controls the options available in the Measure Scoring field. The Measure Scoring field controls the options available in the Patient-based Measure field. Changing the selection in the Composite Scoring Method will reset the Measure Scoring and Patient-based Measure fields. Changing the Measure Scoring field will reset the Patient-based Measure field.";
-	private ListBoxMVP compositeScoringListBox = new ListBoxMVP();
+    private String cautionMsgStr = "Caution: The Composite Scoring Method field controls the options available in the Measure Scoring field. The Measure Scoring field controls the options available in the Patient-based Measure field. Changing the selection in the Composite Scoring Method will reset the Measure Scoring and Patient-based Measure fields. Changing the Measure Scoring field will reset the Patient-based Measure field.";
+    private ListBoxMVP compositeScoringListBox = new ListBoxMVP();
     private FormGroup compositeScoringGroup = new FormGroup();
     protected HTML compScoringMsgPlaceHolder = new HTML();
     private ErrorHandler errorHandler = new ErrorHandler();
-	private String compScoringMsgStr = "<div style=\"padding-left:5px;\">WARNING: Changing the 'Composite Scoring Method and/or Measure Scoring' will have the following impacts:<br/>" +
-			   "<img src='images/bullet.png'/> Populations in the Population Workspace that do not apply to the new settings will be deleted.<br/>" +
-      "<img src='images/bullet.png'/> Existing Groupings in the Measure Packager will be deleted.</div>";
+    private String compScoringMsgStr = "<div style=\"padding-left:5px;\">WARNING: Changing the 'Composite Scoring Method and/or Measure Scoring' will have the following impacts:<br/>" +
+            "<img src='images/bullet.png'/> Populations in the Population Workspace that do not apply to the new settings will be deleted.<br/>" +
+            "<img src='images/bullet.png'/> Existing Groupings in the Measure Packager will be deleted.</div>";
 
-	SaveContinueCancelButtonBar buttonBar = new SaveContinueCancelButtonBar("compositeMeasureDetail");
-	
-	@Override
-	public void clearFields() {
-		super.clearFields();
-		compositeScoringListBox.setSelectedIndex(0);//default to --Select-- value.
-		errorMessages.clearAlert();
-		warningMessageAlert.clearAlert();
-	}
-	
-	public NewCompositeMeasureView() {
-		buildMainPanel();
-		FlowPanel fPanel = buildFlowPanel();
-		
-		measureNameLabel.getElement().setId("measureNameLabel_MeasureNameLabel");
-		Form createMeasureForm = new Form();
-		FormLabel measureNameLabel = buildMeasureNameLabel();
-		buildMeasureNameTextArea();
-		measureNameGroup.add(measureNameLabel);
-		measureNameGroup.add(measureNameTextBox);
+    SaveContinueCancelButtonBar buttonBar = new SaveContinueCancelButtonBar("compositeMeasureDetail");
 
-		//Measure mode type radios
-		addCompositeMeasureModelType();
+    @Override
+    public void clearFields() {
+        super.clearFields();
+        compositeScoringListBox.setSelectedIndex(0);//default to --Select-- value.
+        errorMessages.clearAlert();
+        warningMessageAlert.clearAlert();
+    }
+
+    public NewCompositeMeasureView() {
+        buildMainPanel();
+        FlowPanel fPanel = buildFlowPanel();
+
+        measureNameLabel.getElement().setId("measureNameLabel_MeasureNameLabel");
+        Form createMeasureForm = new Form();
+        FormLabel measureNameLabel = buildMeasureNameLabel();
+        buildMeasureNameTextArea();
+        measureNameGroup.add(measureNameLabel);
+        measureNameGroup.add(measureNameTextBox);
+
+        //Measure mode type radios
+        addCompositeMeasureModelType();
 
         addCompositeGenerateCmsIdCheckbox();
-		
-		HorizontalPanel cqlLibraryNamePanel = buildCQLLibraryNamePanel();
-		cqlLibraryNameGroup.add(cqlLibraryNamePanel);
-		
-		FormLabel shortNameLabel = buildShortNameLabel();
-		buildShortNameTextBox();
-		shortNameGroup.add(shortNameLabel);
-		shortNameGroup.add(eCQMAbbreviatedTitleTextBox);
-		
-		FormLabel compositeScoringLabel = buildCompositeScoringLabel();
-		compositeScoringGroup.add(compositeScoringLabel);
-		buildCompositeScoringInput();
-		HorizontalPanel compositeScoringPanel = buildCompositeScoringPanel();
-		compositeScoringGroup.add(compositeScoringPanel);
-		
-		FormLabel scoringLabel = buildScoringLabel();
-		scoringGroup.add(scoringLabel);
-		buildMeasureScoringInput();
-		HorizontalPanel scoringPanel = buildScoringPanel();
-		scoringGroup.add(scoringPanel);
-		
-		cautionMsgPlaceHolder.getElement().setId("cautionMsgPlaceHolder_HTML");
-		cautionPatientbasedMsgPlaceHolder.getElement().setId("cautionPatientbasedMsgPlaceHolder_HTML");
-		
-		FormLabel patientBasedLabel = buildPatientBasedLabel();
-		patientBasedFormGrp.add(patientBasedLabel);
-		
-		buildPatientBasedInput();
-		
-		HorizontalPanel patientBasedPanel = buildPatientBasedPanel();
-		patientBasedFormGrp.add(patientBasedPanel);
-		
-		FormGroup buttonFormGroup = new FormGroup();
-		buttonBar.getSaveButton().setText("Continue");
-		buttonBar.getSaveButton().setTitle("Continue");
-		buttonFormGroup.add(buttonBar);
-		
-		messageFormGrp.add(helpBlock);
-		messageFormGrp.getElement().setAttribute("role", "alert");
-		
-		FieldSet formFieldSet = buildFormFieldSet();
-		createMeasureForm.add(formFieldSet);
-		createMeasureForm.add(messageFormGrp);
-		fPanel.add(createMeasureForm);
-		mainPanel.add(fPanel);
-	}
-	
-	@Override
-	public HasClickHandlers getCancelButton() {
-		return buttonBar.getCancelButton();
-	}
-	
-	@Override
-	public HasClickHandlers getSaveButton() {
-		return buttonBar.getSaveButton();
-	}
-	
-	protected FlowPanel buildFlowPanel() {
-		FlowPanel fPanel = new FlowPanel();
-		fPanel.getElement().setId("fPanel_FlowPanel");
-		fPanel.setWidth("90%");	
-		fPanel.setHeight("100%");
-		fPanel.add(measureNameLabel);		
-		fPanel.add(requiredInstructions);
-		requiredInstructions.getElement().setId("requiredInstructions_HTML");
-		fPanel.add(new SpacerWidget());
-		HTML cautionHTML = new HTML(cautionMsgStr);
-		fPanel.add(cautionHTML);
-		cautionHTML.getElement().setId("cautionMessage_HTML");
-		
-		fPanel.add(errorMessages);
-		fPanel.add(warningMessageAlert);
-		errorMessages.getElement().setId("errorMessages_ErrorMessageDisplay");
-		
-		fPanel.getElement().appendChild(DOM.createElement(BRElement.TAG));
-		
-		return fPanel;
-	}
-	
-	protected FieldSet buildFormFieldSet() {
-		FormGroup buttonFormGroup = new FormGroup();
-		buttonFormGroup.add(buttonBar);
-		FieldSet formFieldSet = new FieldSet();
-		formFieldSet.add(measureNameGroup);
-		formFieldSet.add(measureModelGroup);
-		formFieldSet.add(generateCmsIdCheckbox);
-		formFieldSet.add(cqlLibraryNameGroup);
-		formFieldSet.add(shortNameGroup);
-		formFieldSet.add(compositeScoringGroup);
-		formFieldSet.add(scoringGroup);
-		formFieldSet.add(patientBasedFormGrp);
-		formFieldSet.add(buttonFormGroup);
-		return formFieldSet;
-	}
-	
-	private FormLabel buildCompositeScoringLabel() {
-		FormLabel scoringLabel = new FormLabel();
-		scoringLabel.setText("Composite Scoring Method");
+        addMatchLibraryNameToCmsIdCheckbox();
+
+        HorizontalPanel cqlLibraryNamePanel = buildCQLLibraryNamePanel();
+        cqlLibraryNameGroup.add(cqlLibraryNamePanel);
+
+        FormLabel shortNameLabel = buildShortNameLabel();
+        buildShortNameTextBox();
+        shortNameGroup.add(shortNameLabel);
+        shortNameGroup.add(eCQMAbbreviatedTitleTextBox);
+
+        FormLabel compositeScoringLabel = buildCompositeScoringLabel();
+        compositeScoringGroup.add(compositeScoringLabel);
+        buildCompositeScoringInput();
+        HorizontalPanel compositeScoringPanel = buildCompositeScoringPanel();
+        compositeScoringGroup.add(compositeScoringPanel);
+
+        FormLabel scoringLabel = buildScoringLabel();
+        scoringGroup.add(scoringLabel);
+        buildMeasureScoringInput();
+        HorizontalPanel scoringPanel = buildScoringPanel();
+        scoringGroup.add(scoringPanel);
+
+        cautionMsgPlaceHolder.getElement().setId("cautionMsgPlaceHolder_HTML");
+        cautionPatientbasedMsgPlaceHolder.getElement().setId("cautionPatientbasedMsgPlaceHolder_HTML");
+
+        FormLabel patientBasedLabel = buildPatientBasedLabel();
+        patientBasedFormGrp.add(patientBasedLabel);
+
+        buildPatientBasedInput();
+
+        HorizontalPanel patientBasedPanel = buildPatientBasedPanel();
+        patientBasedFormGrp.add(patientBasedPanel);
+
+        FormGroup buttonFormGroup = new FormGroup();
+        buttonBar.getSaveButton().setText("Continue");
+        buttonBar.getSaveButton().setTitle("Continue");
+        buttonFormGroup.add(buttonBar);
+
+        messageFormGrp.add(helpBlock);
+        messageFormGrp.getElement().setAttribute("role", "alert");
+
+        FieldSet formFieldSet = buildFormFieldSet();
+        createMeasureForm.add(formFieldSet);
+        createMeasureForm.add(messageFormGrp);
+        fPanel.add(createMeasureForm);
+        mainPanel.add(fPanel);
+    }
+
+    @Override
+    public HasClickHandlers getCancelButton() {
+        return buttonBar.getCancelButton();
+    }
+
+    @Override
+    public HasClickHandlers getSaveButton() {
+        return buttonBar.getSaveButton();
+    }
+
+    protected FlowPanel buildFlowPanel() {
+        FlowPanel fPanel = new FlowPanel();
+        fPanel.getElement().setId("fPanel_FlowPanel");
+        fPanel.setWidth("90%");
+        fPanel.setHeight("100%");
+        fPanel.add(measureNameLabel);
+        fPanel.add(requiredInstructions);
+        requiredInstructions.getElement().setId("requiredInstructions_HTML");
+        fPanel.add(new SpacerWidget());
+        HTML cautionHTML = new HTML(cautionMsgStr);
+        fPanel.add(cautionHTML);
+        cautionHTML.getElement().setId("cautionMessage_HTML");
+
+        fPanel.add(errorMessages);
+        fPanel.add(warningMessageAlert);
+        errorMessages.getElement().setId("errorMessages_ErrorMessageDisplay");
+
+        fPanel.getElement().appendChild(DOM.createElement(BRElement.TAG));
+
+        return fPanel;
+    }
+
+    protected FieldSet buildFormFieldSet() {
+        FormGroup buttonFormGroup = new FormGroup();
+        buttonFormGroup.add(buttonBar);
+        FieldSet formFieldSet = new FieldSet();
+        formFieldSet.add(measureNameGroup);
+        formFieldSet.add(measureModelGroup);
+        formFieldSet.add(nameAndIdOptionGroup);
+        formFieldSet.add(cqlLibraryNameGroup);
+        formFieldSet.add(shortNameGroup);
+        formFieldSet.add(compositeScoringGroup);
+        formFieldSet.add(scoringGroup);
+        formFieldSet.add(patientBasedFormGrp);
+        formFieldSet.add(buttonFormGroup);
+        return formFieldSet;
+    }
+
+    private FormLabel buildCompositeScoringLabel() {
+        FormLabel scoringLabel = new FormLabel();
+        scoringLabel.setText("Composite Scoring Method");
         scoringLabel.setShowRequiredIndicator(true);
-		scoringLabel.setTitle("Composite Scoring Method");
-		scoringLabel.setFor("CompositeScoringMethodListBox");
-		scoringLabel.setId("CompositeScoringMethodListBox");
-		return scoringLabel;
-	}
-	
-	private void buildCompositeScoringInput() {
-		compositeScoringListBox.getElement().setId("compositeScoringInput_ListBoxMVP");
-		compositeScoringListBox.setTitle("Composite Scoring Method Required");
-		compositeScoringListBox.setStyleName("form-control");
-		compositeScoringListBox.setVisibleItemCount(1);
-		compositeScoringListBox.setWidth("18em");
-		compositeScoringListBox.addBlurHandler(errorHandler.buildRequiredBlurHandler(compositeScoringListBox));
-	}
+        scoringLabel.setTitle("Composite Scoring Method");
+        scoringLabel.setFor("CompositeScoringMethodListBox");
+        scoringLabel.setId("CompositeScoringMethodListBox");
+        return scoringLabel;
+    }
 
-	public void setCompositeScoringChoices(List<? extends HasListBox> texts) {
-		MatContext.get().setListBoxItems(compositeScoringListBox, texts, MatContext.PLEASE_SELECT);
-	}
-	
-	public ListBoxMVP getCompositeScoringListBox() {
-		return compositeScoringListBox;
-	}
+    private void buildCompositeScoringInput() {
+        compositeScoringListBox.getElement().setId("compositeScoringInput_ListBoxMVP");
+        compositeScoringListBox.setTitle("Composite Scoring Method Required");
+        compositeScoringListBox.setStyleName("form-control");
+        compositeScoringListBox.setVisibleItemCount(1);
+        compositeScoringListBox.setWidth("18em");
+        compositeScoringListBox.addBlurHandler(errorHandler.buildRequiredBlurHandler(compositeScoringListBox));
+    }
 
-	public String getCompositeScoringValue() {
-		return compositeScoringListBox.getItemText(compositeScoringListBox.getSelectedIndex());
-	}
-	
-	public MessageAlert getErrorMessageDisplay() {
-		return errorMessages;
-	}
-	
-	public void setCompositeScoringSelectedValue(String compositeScoringMethod) {
-		if (CompositeMethodScoringConstant.ALL_OR_NOTHING.equals(compositeScoringMethod)) {
-			getCompositeScoringListBox().setSelectedIndex(1);	
-		} else if (CompositeMethodScoringConstant.OPPORTUNITY.equals(compositeScoringMethod)) {
-			getCompositeScoringListBox().setSelectedIndex(2);
-		} else if (CompositeMethodScoringConstant.PATIENT_LEVEL_LINEAR.equals(compositeScoringMethod)) {
-			getCompositeScoringListBox().setSelectedIndex(3);
-		} else {
-			getCompositeScoringListBox().setSelectedIndex(0);
-		}
-		
-		compositeScoringMethod = StringUtility.isEmptyOrNull(compositeScoringMethod) ? MatContext.PLEASE_SELECT : compositeScoringMethod;
-		setScoringChoices(MatContext.get().getSelectionMap().get(compositeScoringMethod));
-	}
-	
-	@Override
-	public void showCautionMsg(boolean show) {
-		super.showCautionMsg(show);
-		if(show){
-			compScoringMsgPlaceHolder.setHTML(compScoringMsgStr);
-		}else{
-			compScoringMsgPlaceHolder.setHTML("");
-		}
-	}
-	
-	private HorizontalPanel buildCompositeScoringPanel() {
-		HorizontalPanel scoringPanel = new HorizontalPanel();
-		scoringPanel.add(compositeScoringListBox);
-		scoringPanel.add(new HTML("&nbsp;"));
-		scoringPanel.add(compScoringMsgPlaceHolder);
-		return scoringPanel;
-	}
+    public void setCompositeScoringChoices(List<? extends HasListBox> texts) {
+        MatContext.get().setListBoxItems(compositeScoringListBox, texts, MatContext.PLEASE_SELECT);
+    }
+
+    public ListBoxMVP getCompositeScoringListBox() {
+        return compositeScoringListBox;
+    }
+
+    public String getCompositeScoringValue() {
+        return compositeScoringListBox.getItemText(compositeScoringListBox.getSelectedIndex());
+    }
+
+    public MessageAlert getErrorMessageDisplay() {
+        return errorMessages;
+    }
+
+    public void setCompositeScoringSelectedValue(String compositeScoringMethod) {
+        if (CompositeMethodScoringConstant.ALL_OR_NOTHING.equals(compositeScoringMethod)) {
+            getCompositeScoringListBox().setSelectedIndex(1);
+        } else if (CompositeMethodScoringConstant.OPPORTUNITY.equals(compositeScoringMethod)) {
+            getCompositeScoringListBox().setSelectedIndex(2);
+        } else if (CompositeMethodScoringConstant.PATIENT_LEVEL_LINEAR.equals(compositeScoringMethod)) {
+            getCompositeScoringListBox().setSelectedIndex(3);
+        } else {
+            getCompositeScoringListBox().setSelectedIndex(0);
+        }
+
+        compositeScoringMethod = StringUtility.isEmptyOrNull(compositeScoringMethod) ? MatContext.PLEASE_SELECT : compositeScoringMethod;
+        setScoringChoices(MatContext.get().getSelectionMap().get(compositeScoringMethod));
+    }
+
+    @Override
+    public void showCautionMsg(boolean show) {
+        super.showCautionMsg(show);
+        if (show) {
+            compScoringMsgPlaceHolder.setHTML(compScoringMsgStr);
+        } else {
+            compScoringMsgPlaceHolder.setHTML("");
+        }
+    }
+
+    private HorizontalPanel buildCompositeScoringPanel() {
+        HorizontalPanel scoringPanel = new HorizontalPanel();
+        scoringPanel.add(compositeScoringListBox);
+        scoringPanel.add(new HTML("&nbsp;"));
+        scoringPanel.add(compScoringMsgPlaceHolder);
+        return scoringPanel;
+    }
 }
 

--- a/src/main/java/mat/client/measure/NewMeasureView.java
+++ b/src/main/java/mat/client/measure/NewMeasureView.java
@@ -22,6 +22,7 @@ public class NewMeasureView extends AbstractNewMeasureView {
 		addMeasureModelType();
 
 		addGenerateCmsIdCheckbox();
+		addMatchLibraryNameToCmsIdCheckbox();
 		
 		HorizontalPanel cqlLibraryNamePanel = buildCQLLibraryNamePanel();
 		cqlLibraryNameGroup.add(cqlLibraryNamePanel);

--- a/src/main/java/mat/client/validator/ErrorHandler.java
+++ b/src/main/java/mat/client/validator/ErrorHandler.java
@@ -75,12 +75,7 @@ public class ErrorHandler {
     }
 
     public ValidationInfo getValidations(Element field) {
-        ValidationInfo result = validations.get(field);
-        if (result == null) {
-            result = new ValidationInfo();
-            validations.put(field, result);
-        }
-        return result;
+        return validations.computeIfAbsent(field, f -> new ValidationInfo());
     }
 
     public BlurHandler buildRequiredBlurHandler(Widget field) {


### PR DESCRIPTION
**[MAT-2758](https://jira.cms.gov/browse/MAT-2758)**

Split the CQL Library Name option checkbox into two and disable the textbox whenever
the user elects to have the name automatically generated to match the generated
CMS ID.
<!--- Provide the JIRA ticket number and a general summary of your changes in the Title above -->

## Description
Splitting the option into its components makes it clearer to the user what affect each option will have on the resulting measure. These checkboxes should only appear on **New** measure and composite measure pages.

Users may elect to generate a CMS/eCQM ID for the measure and, when selected, they may also elect to match the related CQL Library Name with the generated ID. When a user elects to have both the ID and Library Name generated, the Library Name's textbox is disabled and all field level validations are cleared.

The CMS ID and Library Name are generated on **Save and Continue**. This greatly reduces the chances of another user sniping the ID before the save operation can complete as well as helping to ensure the ID's value increases in numerical order. Also, since the Measure and Library name validators are abstracted away from the presenter, it was difficult to remove the Library name validation whenever the field was disabled. Generating the ID and Name at the start of the save  operation allows for the validation to run normally, which keeps our Library name template in line with what we require of our users.

### Other goodies:
- Modify the Cypress defaults to retain cookies between tests, otherwise MAT fails to successfully run more than one test case
- Correctly ignore mat-cypress bulk in gitignore
- Simplify getValidations implementation
- Condense handler logic and clear validation errors when TextArea is disabled
<!--- Describe your changes in detail -->

## JIRA Ticket
[MAT-2758](https://jira.cms.gov/browse/MAT-2758): Split up option to Generate CMS ID for new measures
<!--- Link to JIRA ticket -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases.
- [x] Tests have been run locally and pass.
![Screen Shot 2021-03-20 at 5 35 14 PM](https://user-images.githubusercontent.com/56264529/111886181-b2a81800-89a2-11eb-9dec-aff600ed9e23.png)

## Screenshots (if appropriate)
### **Single checkbox split into two:**
![Screen Shot 2021-03-08 at 6 06 35 PM](https://user-images.githubusercontent.com/56264529/110711816-26da0300-81ce-11eb-8f10-7964ccb69886.png)
### **Second checkbox enabled when first is checked:**
![Screen Shot 2021-03-08 at 6 06 41 PM](https://user-images.githubusercontent.com/56264529/110711815-26da0300-81ce-11eb-8eee-11e025638b80.png)
### **Related TextBox is disabled when second checkbox is checked:**
![Screen Shot 2021-03-08 at 6 07 08 PM](https://user-images.githubusercontent.com/56264529/110711810-26416c80-81ce-11eb-82b5-ed64c82b6086.png)
### **Above measure's Generate CMS ID option successful:**
![Screen Shot 2021-03-08 at 6 08 29 PM](https://user-images.githubusercontent.com/56264529/110711808-26416c80-81ce-11eb-82bc-ac5bba3a3cde.png)
### **Selecting both options:**
![Screen Shot 2021-03-09 at 4 36 50 PM](https://user-images.githubusercontent.com/56264529/110711807-26416c80-81ce-11eb-9f28-554a23b7bb0a.png)
### **Generate CMS ID successful:**
![Screen Shot 2021-03-09 at 4 37 16 PM](https://user-images.githubusercontent.com/56264529/110711805-25a8d600-81ce-11eb-9c3b-3eee697c875a.png)
### **Match CQL Library Name successful:**
![Screen Shot 2021-03-09 at 4 37 37 PM](https://user-images.githubusercontent.com/56264529/110711804-25a8d600-81ce-11eb-9584-2f8f4a1037e1.png)
### **Draft and Clone pages hide checkboxes:**
![Screen Shot 2021-03-10 at 2 41 36 PM](https://user-images.githubusercontent.com/56264529/110712894-268e3780-81cf-11eb-98d7-1f86be22e1a6.png)
![Screen Shot 2021-03-10 at 2 39 12 PM](https://user-images.githubusercontent.com/56264529/110712901-2726ce00-81cf-11eb-904a-0751c662a371.png)
### **New Composite Measure:**
<img width="1066" alt="Screen Shot 2021-03-10 at 6 35 23 PM" src="https://user-images.githubusercontent.com/56264529/110713169-710fb400-81cf-11eb-90ce-b2e7ea2ea3bb.png">
