### PR TITLE
Lazy load Admin tables

### DIFF
--- a/src/main/java/mat/client/admin/ManageAdminPresenter.java
+++ b/src/main/java/mat/client/admin/ManageAdminPresenter.java
@@ -82,7 +82,7 @@ public class ManageAdminPresenter implements MatPresenter, TabObserver {
 		adminContentWidget.clear();
 		adminContentWidget.add(fp);
 		tabLayout.selectTab(presenterList.indexOf(manageUsersPresenter));
-		manageUsersPresenter.beforeDisplay();
+		manageUsersPresenter.init();
 	}
 
 	@Override

--- a/src/main/java/mat/client/admin/ManageOrganizationPresenter.java
+++ b/src/main/java/mat/client/admin/ManageOrganizationPresenter.java
@@ -139,7 +139,6 @@ public class ManageOrganizationPresenter implements MatPresenter {
 	public ManageOrganizationPresenter(SearchDisplay sDisplayArg, DetailDisplay dDisplayArg) {
 		searchDisplay = sDisplayArg;
 		detailDisplay = dDisplayArg;
-		displaySearch("");
 		searchDisplay.getCreateNewButton().addClickHandler(new ClickHandler() {
 			@Override
 			public void onClick(ClickEvent event) {
@@ -179,7 +178,7 @@ public class ManageOrganizationPresenter implements MatPresenter {
 				isOrgDetailsModified = false;
 				searchDisplay.getErrorMessageDisplay().clearAlert();
 				searchDisplay.getSuccessMessageDisplay().clearAlert();
-				displaySearch(lastSearchKey);
+				displaySearch();
 			}
 		});
 		searchDisplay.getSearchButton().addClickHandler(new ClickHandler() {
@@ -216,7 +215,7 @@ public class ManageOrganizationPresenter implements MatPresenter {
 	 */
 	@Override
 	public void beforeDisplay() {
-		displaySearch("");
+		displaySearch();
 		Mat.focusSkipLists("Manage Organizations");
 	}
 	/** Creates the new. */
@@ -234,13 +233,12 @@ public class ManageOrganizationPresenter implements MatPresenter {
 		Mat.focusSkipLists("Manage Organizations");
 	}
 	/** Display search. */
-	private void displaySearch(String organization) {
+	private void displaySearch() {
 		panel.clear();
 		panel.add(searchDisplay.asWidget());
 		searchDisplay.getErrorMessageDisplay().clearAlert();
 		searchDisplay.getSuccessMessageDisplay().clearAlert();
 		searchDisplay.setTitle("");
-		search(organization);
 	}
 	/** Edits the.
 	 * @param key the key */
@@ -352,7 +350,7 @@ public class ManageOrganizationPresenter implements MatPresenter {
 					}
 					@Override
 					public void onSuccess(Void res) {
-						displaySearch(lastSearchKey);
+						displaySearch();
 						searchDisplay.getSuccessMessageDisplay().createAlert(result.getOrgName()+" successfully deleted.");
 					}
 				});
@@ -404,7 +402,7 @@ public class ManageOrganizationPresenter implements MatPresenter {
 						isOrgDetailsModified = false;
 						currentOrganizationDetails = updatedOrganizationDetailModel;
 						setOrganizationDetailsToView();
-						displaySearch(lastSearchKey);
+						displaySearch();
 						searchDisplay.getSuccessMessageDisplay().createAlert(MatContext.get()
 								.getMessageDelegate().getORGANIZATION_MODIFIED_SUCCESS_MESSAGE());
 					} else {
@@ -434,7 +432,7 @@ public class ManageOrganizationPresenter implements MatPresenter {
 						isOrgDetailsModified = false;
 						currentOrganizationDetails = updatedOrganizationDetailModel;
 						setOrganizationDetailsToView();
-						displaySearch(lastSearchKey);
+						displaySearch();
 						searchDisplay.getSuccessMessageDisplay().createAlert(MatContext.get()
 								.getMessageDelegate().getORGANIZATION_SUCCESS_MESSAGE());
 					} else {

--- a/src/main/java/mat/client/admin/ManageUsersPresenter.java
+++ b/src/main/java/mat/client/admin/ManageUsersPresenter.java
@@ -78,7 +78,6 @@ public class ManageUsersPresenter implements MatPresenter {
         searchDisplay = sDisplayArg;
         detailDisplay = dDisplayArg;
         historyDisplay = hDisplayArg;
-        displaySearch("");
 
         if (historyDisplay != null) {
             historyDisplayHandlers(historyDisplay);
@@ -104,7 +103,7 @@ public class ManageUsersPresenter implements MatPresenter {
 
         detailDisplay.getSaveButton().addClickHandler(event -> onSaveButtonClicked());
 
-        detailDisplay.getCancelButton().addClickHandler(event -> displaySearch(lastSearchKey));
+        detailDisplay.getCancelButton().addClickHandler(event -> displaySearch());
 
         detailDisplay.getReactivateAccountButton().addClickHandler(
                 event -> {
@@ -155,15 +154,21 @@ public class ManageUsersPresenter implements MatPresenter {
         searchDisplay.getSuccessMessageDisplay().clearAlert();
     }
 
-    /**
-     * Display search.
-     */
-    private void displaySearch(String name) {
+    public void init() {
         panel.setContent(searchDisplay.asWidget());
         panel.setHeading("", "");
         searchDisplay.setTitle("");
         searchDisplay.getSuccessMessageDisplay().clearAlert();
-        search(name);
+    }
+
+    /**
+     * Display search.
+     */
+    private void displaySearch() {
+        panel.setContent(searchDisplay.asWidget());
+        panel.setHeading("", "");
+        searchDisplay.setTitle("");
+        searchDisplay.getSuccessMessageDisplay().clearAlert();
     }
 
     /**
@@ -365,7 +370,7 @@ public class ManageUsersPresenter implements MatPresenter {
             detailDisplay.getHarpId().setValue(currentDetails.getHarpId());
             detailDisplay.getPhoneNumber().setValue(currentDetails.getPhoneNumber());
             detailDisplay.getOid().setValue(currentDetails.getOid());
-            displaySearch(lastSearchKey);
+            displaySearch();
             searchDisplay.getSuccessMessageDisplay().createAlert(MatContext.get().getMessageDelegate().getUSER_SUCCESS_MESSAGE() + actMsg);
         } else {
             List<String> messages = getAlertMessages(result);
@@ -411,7 +416,7 @@ public class ManageUsersPresenter implements MatPresenter {
             public void onSuccess(ManageUsersDetailModel result) {
                 logger.log(Level.INFO, "AdminService::getUserByEmail -> onSuccess");
                 currentDetails = result;
-                displaySearch(lastSearchKey);
+                displaySearch();
                 searchDisplay.getSuccessMessageDisplay().createAlert(MatContext.get().getMessageDelegate().getUSER_SUCCESS_MESSAGE());
 
                 List<String> event = new ArrayList<String>();
@@ -576,7 +581,7 @@ public class ManageUsersPresenter implements MatPresenter {
      */
     @Override
     public void beforeDisplay() {
-        displaySearch("");
+        displaySearch();
         Mat.focusSkipLists("Manage Users");
     }
 
@@ -698,7 +703,7 @@ public class ManageUsersPresenter implements MatPresenter {
         historyDisplay.getReturnToLink().addClickHandler(new ClickHandler() {
             @Override
             public void onClick(ClickEvent event) {
-                displaySearch(lastSearchKey);
+                displaySearch();
             }
         });
     }


### PR DESCRIPTION
To reduce the number of server calls, don't load the contents of the user and organization tables when the page loads.

Removing on-page table loads from Admin's user and organization tabs.

<!--- Provide the JIRA ticket number and a general summary of your changes in the Title above -->

## Description
When loading into the MAT as an Admin User, the User and Organization tables will no longer populate until the user clicks on the `Search` button.

Once loaded, the tables will remain populated until a new search query is submitted.

## JIRA Ticket
<!--- Link to JIRA ticket -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
