### PR TITLE
Pull down jackson-annotations dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <jacoco.version>0.8.6</jacoco.version>
         <jaxb.version>2.3.0</jaxb.version>
         <hapi-fhir-version>4.1.0</hapi-fhir-version>
+        <jackson.version>2.12.3</jackson.version>
 
         <gwt.sourceLevel>1.8</gwt.sourceLevel>
         <java.version>11</java.version>
@@ -128,12 +129,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.3</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.12.3</version>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
@@ -256,6 +262,7 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-tomcat</artifactId>
                 </exclusion>
+                <!-- exclude jackson-databind in favor of newer version -->
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>


### PR DESCRIPTION
<!--- Provide the JIRA ticket number and a general summary of your changes in the Title above -->
Set a specific version of jackson-core & jackson-annotations

## Description
Latest `jackson-databind` pulls down older versions of `jackson-core` and `jackson-annotations` that aren't compatible with the current version of Spring, and we want the latest `jackson-databind` for its security fixes.

## JIRA Ticket
<!--- Link to JIRA ticket -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
- [ ] None applicable
