### PR TITLE
BugFix MAT-2881, invalid message on save of MO

### DIFF
--- a/src/main/java/mat/server/MeasureLibraryServiceImpl.java
+++ b/src/main/java/mat/server/MeasureLibraryServiceImpl.java
@@ -2275,7 +2275,7 @@ public class MeasureLibraryServiceImpl implements MeasureLibraryService {
         MeasureXmlModel xmlModel = measurePackageService.getMeasureXmlForMeasure(measure.getId());
         XmlProcessor xmlProcessor = new XmlProcessor(xmlModel.getXml());
 
-        xmlProcessor.checkForScoringType(propertiesService.getQdmVersion(), model.getMeasScoring(), model.isPatientBased());
+        xmlProcessor.checkForScoringType(propertiesService.getQdmVersion(), model.getMeasScoring());
         if (!existingMeasureScoringType.equalsIgnoreCase(model.getMeasScoring()) || (model.getPopulationBasis() != null && !model.getPopulationBasis().equalsIgnoreCase(existingMeasurePopulationBasis))) {
             deleteExistingGroupings(xmlProcessor);
             MatContext.get().setCurrentMeasureScoringType(model.getMeasScoring());

--- a/src/main/java/mat/server/MeasureLibraryServiceImpl.java
+++ b/src/main/java/mat/server/MeasureLibraryServiceImpl.java
@@ -2275,7 +2275,7 @@ public class MeasureLibraryServiceImpl implements MeasureLibraryService {
         MeasureXmlModel xmlModel = measurePackageService.getMeasureXmlForMeasure(measure.getId());
         XmlProcessor xmlProcessor = new XmlProcessor(xmlModel.getXml());
 
-        xmlProcessor.checkForScoringType(propertiesService.getQdmVersion(), model.getMeasScoring());
+        xmlProcessor.checkForScoringType(model.getMeasScoring());
         if (!existingMeasureScoringType.equalsIgnoreCase(model.getMeasScoring()) || (model.getPopulationBasis() != null && !model.getPopulationBasis().equalsIgnoreCase(existingMeasurePopulationBasis))) {
             deleteExistingGroupings(xmlProcessor);
             MatContext.get().setCurrentMeasureScoringType(model.getMeasScoring());

--- a/src/main/java/mat/server/service/impl/MeasureCloningServiceImpl.java
+++ b/src/main/java/mat/server/service/impl/MeasureCloningServiceImpl.java
@@ -354,7 +354,7 @@ public class MeasureCloningServiceImpl implements MeasureCloningService {
             } catch (XPathExpressionException e) {
                 throw new MatException(e);
             }
-            createNewNodesBasedOnScoring(xmlProcessor, clonedMeasure, scoringTypeId);
+            createNewNodesBasedOnScoring(xmlProcessor, scoringTypeId);
         }
     }
 
@@ -563,7 +563,7 @@ public class MeasureCloningServiceImpl implements MeasureCloningService {
 
         String scoringTypeId = clonedMeasure.getMeasureScoring();
 
-        createNewNodesBasedOnScoring(xmlProcessor, clonedMeasure, scoringTypeId);
+        createNewNodesBasedOnScoring(xmlProcessor, scoringTypeId);
 
         generateCqlLookupTag(xmlProcessor, clonedMeasure, creatingFhir);
 
@@ -597,9 +597,9 @@ public class MeasureCloningServiceImpl implements MeasureCloningService {
         }
     }
 
-    private void createNewNodesBasedOnScoring(XmlProcessor xmlProcessor, Measure clonedMeasure, String scoringTypeId) throws MatException {
+    private void createNewNodesBasedOnScoring(XmlProcessor xmlProcessor, String scoringTypeId) throws MatException {
         try {
-            xmlProcessor.createNewNodesBasedOnScoring(scoringTypeId, propertiesService.getQdmVersion());
+            xmlProcessor.createNewNodesBasedOnScoring(scoringTypeId);
         } catch (XPathExpressionException e) {
             throw new MatException(e);
         }

--- a/src/main/java/mat/server/service/impl/MeasureCloningServiceImpl.java
+++ b/src/main/java/mat/server/service/impl/MeasureCloningServiceImpl.java
@@ -350,7 +350,7 @@ public class MeasureCloningServiceImpl implements MeasureCloningService {
         if (!measure.getMeasureScoring().equals(currentDetails.getMeasScoring()) || currentDetails.isPatientBased()) {
             String scoringTypeId = clonedMeasure.getMeasureScoring();
             try {
-                xmlProcessor.removeNodesBasedOnScoring(scoringTypeId, currentDetails.isPatientBased());
+                xmlProcessor.removeNodesBasedOnScoring(scoringTypeId);
             } catch (XPathExpressionException e) {
                 throw new MatException(e);
             }
@@ -599,7 +599,7 @@ public class MeasureCloningServiceImpl implements MeasureCloningService {
 
     private void createNewNodesBasedOnScoring(XmlProcessor xmlProcessor, Measure clonedMeasure, String scoringTypeId) throws MatException {
         try {
-            xmlProcessor.createNewNodesBasedOnScoring(scoringTypeId, propertiesService.getQdmVersion(), clonedMeasure.getPatientBased());
+            xmlProcessor.createNewNodesBasedOnScoring(scoringTypeId, propertiesService.getQdmVersion());
         } catch (XPathExpressionException e) {
             throw new MatException(e);
         }

--- a/src/main/java/mat/server/util/XmlProcessor.java
+++ b/src/main/java/mat/server/util/XmlProcessor.java
@@ -402,13 +402,13 @@ public class XmlProcessor {
      *
      * @return the string
      */
-    public String checkForScoringType(String releaseVersion, String scoringType) {
+    public String checkForScoringType(String scoringType) {
         if (originalDoc == null) {
             return "";
         }
         try {
             removeNodesBasedOnScoring(scoringType);
-            createNewNodesBasedOnScoring(scoringType, releaseVersion);
+            createNewNodesBasedOnScoring(scoringType);
         } catch (XPathExpressionException e) {
             LOG.error(e.getMessage(), e);
         }
@@ -566,10 +566,9 @@ public class XmlProcessor {
      * on the value of Scoring Type.
      *
      * @param scoringType    the scoring type
-     * @param releaseVersion
      * @throws XPathExpressionException the x path expression exception
      */
-    public void createNewNodesBasedOnScoring(String scoringType, String releaseVersion)
+    public void createNewNodesBasedOnScoring(String scoringType)
             throws XPathExpressionException {
         List<String> scoreBasedNodes = retrieveScoreBasedNodes(scoringType);
         Node populationsNode = findNode(originalDoc, XPATH_POPULATIONS);
@@ -641,11 +640,7 @@ public class XmlProcessor {
             measureElement.removeChild(measureStratificationsNode);
         }
         // Create supplementalDataElements node
-        releaseVersion = releaseVersion.replaceAll("Draft ", "").trim();
-        if (releaseVersion.startsWith("v")) {
-            releaseVersion = releaseVersion.substring(1);
-        }
-        createSupplementalDataElementNode(measureStratificationsNode, releaseVersion);
+        createSupplementalDataElementNode(measureStratificationsNode);
         /*
          * All the adding and removing can put the children of 'populations' in
          * a random order. Arrange the population nodes in correct order.*/
@@ -703,11 +698,9 @@ public class XmlProcessor {
      * Creates the Supplemental Data Element Node.
      *
      * @param measureStratificationsNode stratifications Node for the measure
-     * @param releaseVersion
      * @throws XPathExpressionException the x path expression exception
      */
-    private void createSupplementalDataElementNode(
-            Node measureStratificationsNode, String releaseVersion) throws XPathExpressionException {
+    private void createSupplementalDataElementNode(Node measureStratificationsNode) throws XPathExpressionException {
         Node supplementaDataElementsElement = findNode(originalDoc,
                 XPATH_MEASURE_SD_ELEMENTS);
         if (supplementaDataElementsElement == null) {

--- a/src/main/java/mat/server/util/XmlProcessor.java
+++ b/src/main/java/mat/server/util/XmlProcessor.java
@@ -402,13 +402,13 @@ public class XmlProcessor {
      *
      * @return the string
      */
-    public String checkForScoringType(String releaseVersion, String scoringType, boolean isPatientBased) {
+    public String checkForScoringType(String releaseVersion, String scoringType) {
         if (originalDoc == null) {
             return "";
         }
         try {
-            removeNodesBasedOnScoring(scoringType, isPatientBased);
-            createNewNodesBasedOnScoring(scoringType, releaseVersion, isPatientBased);
+            removeNodesBasedOnScoring(scoringType);
+            createNewNodesBasedOnScoring(scoringType, releaseVersion);
         } catch (XPathExpressionException e) {
             LOG.error(e.getMessage(), e);
         }
@@ -422,7 +422,7 @@ public class XmlProcessor {
      * @param scoringType the scoring type
      * @throws XPathExpressionException the x path expression exception
      */
-    public void removeNodesBasedOnScoring(String scoringType, boolean isPatientBased) throws XPathExpressionException {
+    public void removeNodesBasedOnScoring(String scoringType) throws XPathExpressionException {
         List<String> xPathList = new ArrayList<String>();
 
         if (RATIO.equalsIgnoreCase(scoringType)) {
@@ -430,18 +430,11 @@ public class XmlProcessor {
             xPathList.add(XPATH_DENOMINATOR_EXCEPTIONS);
             xPathList.add(XPATH_MEASURE_POPULATIONS);
             xPathList.add(XPATH_MEASURE_POPULATION_EXCLUSIONS);
-
-            //Measure Observations section is not available for
-            //Patient Based Ratio Measures. Hence adding to Remove list
-            if (isPatientBased) {
-                xPathList.add(XPATH_MEASURE_OBSERVATIONS);
-            }
         } else if (PROPORTION.equalsIgnoreCase(scoringType)) {
             // Measure Population Exlusions, Measure Populations
             xPathList.add(XPATH_MEASURE_POPULATIONS);
             xPathList.add(XPATH_MEASURE_POPULATION_EXCLUSIONS);
             xPathList.add(XPATH_MEASURE_OBSERVATIONS);
-
         } else if (CONTINUOUS_VARIABLE.equalsIgnoreCase(scoringType)) {
             // Numerators,Numerator Exclusions, Denominators, Denominator
             // Exceptions, Denominator Exclusions
@@ -450,7 +443,6 @@ public class XmlProcessor {
             xPathList.add(XPATH_DENOMINATOR);
             xPathList.add(XPATH_DENOMINATOR_EXCEPTIONS);
             xPathList.add(XPATH_DENOMINATOR_EXCLUSIONS);
-
         } else if (COHORT.equalsIgnoreCase(scoringType)) {
             xPathList.add(XPATH_NUMERATORS);
             xPathList.add(XPATH_NUMERATOR_EXCLUSIONS);
@@ -577,7 +569,7 @@ public class XmlProcessor {
      * @param releaseVersion
      * @throws XPathExpressionException the x path expression exception
      */
-    public void createNewNodesBasedOnScoring(String scoringType, String releaseVersion, boolean isPatientBased)
+    public void createNewNodesBasedOnScoring(String scoringType, String releaseVersion)
             throws XPathExpressionException {
         List<String> scoreBasedNodes = retrieveScoreBasedNodes(scoringType);
         Node populationsNode = findNode(originalDoc, XPATH_POPULATIONS);
@@ -592,7 +584,7 @@ public class XmlProcessor {
          * and scoring type is Continuous Variable.
          */
         Node measureObservationsNode = findNode(originalDoc, XPATH_MEASURE_OBSERVATIONS);
-        if ((CONTINUOUS_VARIABLE.equalsIgnoreCase(scoringType) || (RATIO.equalsIgnoreCase(scoringType) && !isPatientBased))
+        if ((CONTINUOUS_VARIABLE.equalsIgnoreCase(scoringType) || RATIO.equalsIgnoreCase(scoringType))
                 && (measureObservationsNode == null)) {
             // Create a new measureObservations element.
             String nodeName = MEASURE_OBSERVATION;


### PR DESCRIPTION
<!--- Provide the JIRA ticket number and a general summary of your changes in the Title above -->
MAT-2881
## Description
<!--- Describe your changes in detail -->
On save of Measure Observations for Patient Based Ratio measures, the Heading and the success message is not populated as expected, this is because these UI elements are displayed from the data provided in measure XML. 

- When creating a new measure, MAT will create empty nodes for all possible 'populations' based on 'scoring type' in Measure xml.
- For Patient based ratio measures, these nodes are not created when creating a new measure. Although these nodes are added upon save.
- these empty nodes are necessary to render the UI elements.
## JIRA Ticket
<!--- Link to JIRA ticket -->
[https://jira.cms.gov/browse/MAT-2881](MAT-2881)
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
- [ ] None applicable
