### PR TITLE
Updated text to 5.6 in measure Xml for existing 5.5 draft measures

### DIFF
--- a/src/main/java/liquibase/QDM_5_6_MeasureXmlUpdate.xml
+++ b/src/main/java/liquibase/QDM_5_6_MeasureXmlUpdate.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="mat_dev_user" id="1" context="prod">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="MEASURE_XML"/>
+        </preConditions>
+        <update tableName="MEASURE_XML">
+            <column name="MEASURE_XML" valueComputed="REPLACE(MEASURE_XML, '&lt;usingModelVersion&gt;5.5&lt;/usingModelVersion&gt;', '&lt;usingModelVersion&gt;5.6&lt;/usingModelVersion&gt;')"/>
+            <where>MEASURE_ID IN (SELECT m.ID FROM MEASURE m WHERE m.MEASURE_MODEL = 'QDM' AND m.QDM_VERSION = '5.6' AND m.DRAFT = 1)</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/java/liquibase/QDM_5_6_MeasureXmlUpdate_v2.xml
+++ b/src/main/java/liquibase/QDM_5_6_MeasureXmlUpdate_v2.xml
@@ -6,10 +6,15 @@
     <changeSet author="mat_dev_user" id="1" context="prod">
         <preConditions onFail="MARK_RAN">
             <tableExists tableName="MEASURE_XML"/>
+            <tableExists tableName="CQL_LIBRARY"/>
         </preConditions>
         <update tableName="MEASURE_XML">
             <column name="MEASURE_XML" valueComputed="REPLACE(MEASURE_XML, '&lt;usingModelVersion&gt;5.5&lt;/usingModelVersion&gt;', '&lt;usingModelVersion&gt;5.6&lt;/usingModelVersion&gt;')"/>
             <where>MEASURE_ID IN (SELECT m.ID FROM MEASURE m WHERE m.MEASURE_MODEL = 'QDM' AND m.QDM_VERSION = '5.6' AND m.DRAFT = 1)</where>
+        </update>
+        <update tableName="CQL_LIBRARY">
+            <column name="CQL_XML" valueComputed="REPLACE(CQL_XML, '&lt;usingModelVersion&gt;5.5&lt;/usingModelVersion&gt;', '&lt;usingModelVersion&gt;5.6&lt;/usingModelVersion&gt;')"/>
+                <where>LIBRARY_MODEL = 'QDM' AND QDM_VERSION = '5.6' AND DRAFT = 1</where>
         </update>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/java/liquibase/changelog.xml
+++ b/src/main/java/liquibase/changelog.xml
@@ -9,4 +9,5 @@
     <include file="classpath:/liquibase/QDM_5_6_Updates_v4.xml"/>
     <include file="classpath:/liquibase/Qdm_5_6_versionUpdate_v2.xml"/>
     <include file="classpath:/liquibase/QDM_5_6_DataType_Update_v2.xml"/>
+    <include file="classpath:/liquibase/QDM_5_6_MeasureXmlUpdate.xml"/>
 </databaseChangeLog>

--- a/src/main/java/liquibase/changelog.xml
+++ b/src/main/java/liquibase/changelog.xml
@@ -9,5 +9,5 @@
     <include file="classpath:/liquibase/QDM_5_6_Updates_v4.xml"/>
     <include file="classpath:/liquibase/Qdm_5_6_versionUpdate_v2.xml"/>
     <include file="classpath:/liquibase/QDM_5_6_DataType_Update_v2.xml"/>
-    <include file="classpath:/liquibase/QDM_5_6_MeasureXmlUpdate.xml"/>
+    <include file="classpath:/liquibase/QDM_5_6_MeasureXmlUpdate_v2.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
<!--- Provide the JIRA ticket number and a general summary of your changes in the Title above -->
MAT-2833
## Description
<!--- Describe your changes in detail -->

- Liquibase script to update text in Measure XML for existing QDM draft 5.5 measures. 
- Although QDM_VERSION of these measures are already updated to 5.6. So the query reads QDM_VERSION = '5.6'
- Since the script is written in XML, I have to escape '<' and '>' characters with &lt; and &gt; respectively.
- I added an update statement for StandAlone Cql libraries. so that all draft 5.6 Cql libraries will have ‘5.6’ as text in their Cql. 
- This liquibase script also updated the Model version in the General information tab.
![image](https://user-images.githubusercontent.com/57495404/116129576-4226a200-a698-11eb-8796-d8986c51f163.png)
![image](https://user-images.githubusercontent.com/57495404/116129605-4b177380-a698-11eb-8939-6552f85d3dbc.png)

## JIRA Ticket
<!--- Link to JIRA ticket -->
[MAT-2833](https://jira.cms.gov/browse/MAT-2833)
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
- [ ] None applicable
