### PR TITLE
Added a check to see if the revision number is '0' instead of '000'

### DIFF
--- a/src/main/java/mat/model/clause/CQLLibrary.java
+++ b/src/main/java/mat/model/clause/CQLLibrary.java
@@ -414,8 +414,8 @@ public class CQLLibrary {
 
     @Transient
     public String getMatVersion() {
-        String version = getVersion().toString();
-        String revision = getRevisionNumber().toString();
+        String version = getVersion();
+        String revision = getRevisionNumber();
 
         String[] split = version.split("\\.");
 

--- a/src/main/java/mat/server/CQLLibraryService.java
+++ b/src/main/java/mat/server/CQLLibraryService.java
@@ -249,7 +249,7 @@ public class CQLLibraryService extends SpringRemoteServiceServlet implements CQL
         dataSetObject.setReleaseVersion(cqlLibrary.getReleaseVersion());
         dataSetObject.setQdmVersion(cqlLibrary.getQdmVersion());
         dataSetObject.setFhirVersion(cqlLibrary.getFhirVersion());
-        if (cqlLibrary.getRevisionNumber() == null) {
+        if (cqlLibrary.getRevisionNumber() == null || cqlLibrary.getRevisionNumber().equalsIgnoreCase("0")) {
             dataSetObject.setRevisionNumber("000");
         } else {
             dataSetObject.setRevisionNumber(cqlLibrary.getRevisionNumber());


### PR DESCRIPTION
<!--- Provide the JIRA ticket number and a general summary of your changes in the Title above -->
MAT-2832
## Description
<!--- Describe your changes in detail -->
The revision number of Cql library is retrieved as '0' and is stored in measure XML, but the actual cql library will have '000' as the revision number. This mismatch is causing an issue while replacing the included libraries from helper UI. 
Solution: While retrieving the cql Library, if the revision number is '0' then we are returning '000' instead So that it could be saved as '000' in measure Xml.


## JIRA Ticket
<!--- Link to JIRA ticket -->
[MAT-2832](https://jira.cms.gov/browse/MAT-2832)
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
- [ ] None applicable
