### PR TITLE
[MAT-2974] Don't display empty Score Units in HQMF artifacts

### DIFF
--- a/src/main/java/mat/server/hqmf/qdm_5_6/HQMFPopulationLogicGenerator.java
+++ b/src/main/java/mat/server/hqmf/qdm_5_6/HQMFPopulationLogicGenerator.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 // TODO: Auto-generated Javadoc
 
 /**
@@ -161,7 +163,7 @@ public class HQMFPopulationLogicGenerator extends HQMFClauseLogicGenerator {
 	}
 
 	private void createScoreUnit(MeasureExport me, Node populationCriteriaSection, String scoreUnit) {
-		if (scoreUnit == null) {
+		if (StringUtils.isBlank(scoreUnit)) {
 			// No Score Unit provided in measure group
 			return;
 		}
@@ -388,8 +390,9 @@ public class HQMFPopulationLogicGenerator extends HQMFClauseLogicGenerator {
 					.packageClauses(childNodeList)
 					.build();
 
-			if (measureGroupings.item(i).getAttributes().getNamedItem("ucum") != null) {
-				measureGroup.setScoreUnit(measureGroupings.item(i).getAttributes().getNamedItem("ucum").getNodeValue());
+			Node ucum = measureGroupings.item(i).getAttributes().getNamedItem("ucum");
+			if (ucum != null && isNotBlank(ucum.getNodeValue().strip())) {
+				measureGroup.setScoreUnit(ucum.getNodeValue().strip());
 			}
 
 			measureGroupingMap.put(measureGroupingSequence, measureGroup);

--- a/src/main/java/mat/server/humanreadable/HumanReadableGenerator.java
+++ b/src/main/java/mat/server/humanreadable/HumanReadableGenerator.java
@@ -652,7 +652,7 @@ public class HumanReadableGenerator {
             populations = sortPopulations(populations);
 
             String displayName = "Population Criteria " + populationCriteriaNumber;
-            String scoreUnit = group.getAttributes().getNamedItem("ucum").getNodeValue();
+            String scoreUnit = group.getAttributes().getNamedItem("ucum").getNodeValue().strip();
             HumanReadablePopulationCriteriaModel populationCriteria = new HumanReadablePopulationCriteriaModel(displayName, populations, populationCriteriaNumber, scoreUnit);
             groups.add(populationCriteria);
         }


### PR DESCRIPTION
## Description
- Add stricter check for populated Target Units
- Strip whitespace from ucum value

## JIRA Ticket
[MAT-2974](https://jira.cms.gov/browse/MAT-2974)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
