### PR TITLE
[MAT-2824] FHIR: Delete DRCs that reference versionless Code Systems

### DIFF
--- a/pmd.xml
+++ b/pmd.xml
@@ -13,6 +13,7 @@
    <include-pattern>.*/mat/server/hqmf/qdm_5_6/.*</include-pattern>
    <include-pattern>.*/mat/server/humanreadable/.*</include-pattern>
    <include-pattern>.*/mat/server/service/impl/MeasurePackageServiceImpl.java</include-pattern>
+   <include-pattern>.*/mat/server/CQLServiceImpl.java</include-pattern>
 
    <rule ref="category/java/bestpractices.xml">
       <exclude name="AbstractClassWithoutAbstractMethod"/>


### PR DESCRIPTION
## Description
Updating DRC handling to check for null code system version before attempting to extract the value from a non-existent element in the measure xml.

This is currently a FHIR only issue, as QDM measures lock DRC changes to the helper UI where the version is maintained in the backing model.

For both FHIR and QDM, when a code system is added to the CQL via the helper UI (by adding a code), its version is maintained in the model regardless of the "include version" option even though the generated CQL will not contain the version if the "include version" option was not selected. For FHIR, saving from the CQL Editor overwrites the DRCs and Code Systems in the back model. Therefore, the backing model will lose the code system version value whenever CQL without the version component is saved from the CQL Editor. Pre-existing code handling always assumed the version value would be present in the backing model, causing NPEs on delete and add when a DRC with a versionless CS was already present.


## JIRA Ticket
[MAT-2824](https://jira.cms.gov/browse/MAT-2824)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
<!--- Put an `x` in the box when Screenshots are not relevant. Delete below line if adding screenshots. -->
- [x] None applicable
