### PR TITLE
Added FileNameExtensions for zip folders

### DIFF
--- a/src/main/java/mat/server/ExportServlet.java
+++ b/src/main/java/mat/server/ExportServlet.java
@@ -299,9 +299,9 @@ public class ExportServlet extends HttpServlet {
 
         if (!export.getIncludedCQLExports().isEmpty()) {
             ZipPackager zp = context.getBean(ZipPackagerFactory.class).getZipPackager();
-            zp.getCQLZipBarr(measure, export, extension);
+            zp.getCQLZipBarr(measure, export, extension, fileNameExtension);
 
-            resp.setHeader(CONTENT_DISPOSITION, ATTACHMENT_FILENAME + FileNameUtility.getExportBundleZipName(measure));
+            resp.setHeader(CONTENT_DISPOSITION, ATTACHMENT_FILENAME + FileNameUtility.getExportFolderNameWithExtension(measure, fileNameExtension) + ".zip");
             resp.setContentType(APPLICATION_ZIP);
             resp.getOutputStream().write(export.getZipbarr());
             export.setZipbarr(null);

--- a/src/main/java/mat/server/service/impl/ZipPackager.java
+++ b/src/main/java/mat/server/service/impl/ZipPackager.java
@@ -298,14 +298,14 @@ public class ZipPackager {
     }
 
 
-    public byte[] getCQLZipBarr(Measure measure, ExportResult export, String extension) {
+    public byte[] getCQLZipBarr(Measure measure, ExportResult export, String extension, String fileNameExtension) {
         byte[] ret = null;
 
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             ZipOutputStream zip = new ZipOutputStream(baos);
 
-            String parentPath = FileNameUtility.getExportFileName(measure);
+            String parentPath = FileNameUtility.getExportFolderNameWithExtension(measure, fileNameExtension);
 
             addFileToZip(measure, export, parentPath, extension, zip);
 

--- a/src/main/java/mat/shared/FileNameUtility.java
+++ b/src/main/java/mat/shared/FileNameUtility.java
@@ -3,6 +3,7 @@ package mat.shared;
 import mat.model.clause.Measure;
 import mat.server.export.ExportResult;
 import mat.server.util.MeasureUtility;
+
 import java.text.DecimalFormat;
 
 public class FileNameUtility {
@@ -10,8 +11,7 @@ public class FileNameUtility {
     private static final DecimalFormat revisionFormat = new DecimalFormat("000");
 
     public static String getExportBundleZipName(Measure measure) {
-        return replaceUnderscores(measure.getaBBRName()) + "-v" +
-                getMeasureVersion(measure) + "-" + measure.getMeasureModel() + "-" + getModelVersion(measure) + ".zip";
+        return getExportFileName(measure) + ".zip";
     }
 
     public static String getBulkExportZipName(String name) {
@@ -37,6 +37,10 @@ public class FileNameUtility {
         String measureVersion = MeasureUtility.formatVersionText(measure.getVersion());
         return replacePeriods(measure.isDraft() ?
                 measureVersion + "." + revisionFormat.format(Integer.parseInt(measure.getRevisionNumber())) : measureVersion);
+    }
+
+    public static String getExportFolderNameWithExtension(Measure measure, String fileNameExtension) {
+        return getExportFileName(measure) + "-" + fileNameExtension;
     }
 
     public static String replaceUnderscores(String s) {


### PR DESCRIPTION
<!--- In the *Title* field above, please provide the JIRA ticket number and a general summary of your changes -->
## Description
<!--- Describe your changes in detail -->
For QDM measure, when a user exports either of these 3 'cql', 'json', 'xml' and if a zip folder is downloaded, an appropriate keyword is added at the end, so that these folders can be differentiated. 
## JIRA Ticket
<!--- Link to JIRA ticket -->
[MAT-2994](https://jira.cms.gov/browse/MAT-2994)
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
<!--- Put an `x` in the box when Screenshots are not relevant. Delete below line if adding screenshots. -->



