### PR TITLE
Fixed loading spinner for unsaved definitions

### DIFF
--- a/src/main/java/mat/client/cqlworkspace/CQLMeasureWorkSpacePresenter.java
+++ b/src/main/java/mat/client/cqlworkspace/CQLMeasureWorkSpacePresenter.java
@@ -2241,7 +2241,6 @@ public class CQLMeasureWorkSpacePresenter extends AbstractCQLWorkspacePresenter 
         if (cqlWorkspaceView.getCQLLeftNavBarPanelView().getIsLoading()) {
             event.stopPropagation();
         } else {
-            showSearchBusyOnDoubleClick(true);
             cqlWorkspaceView.getCQLDefinitionsView().getDefineAceEditor().clearAnnotations();
             cqlWorkspaceView.getCQLDefinitionsView().getDefineAceEditor().removeAllMarkers();
             resetAceEditor(cqlWorkspaceView.getCQLDefinitionsView().getViewCQLAceEditor());
@@ -2249,9 +2248,9 @@ public class CQLMeasureWorkSpacePresenter extends AbstractCQLWorkspacePresenter 
             cqlWorkspaceView.getCQLDefinitionsView().getReturnTypeTextBox().setText(EMPTY_STRING);
             cqlWorkspaceView.getCQLLeftNavBarPanelView().setIsDoubleClick(true);
             if (getIsPageDirty()) {
-                //showSearchBusyOnDoubleClick(false);
                 showUnsavedChangesWarning();
             } else {
+                showSearchBusyOnDoubleClick(true);
                 int selectedIndex = cqlWorkspaceView.getCQLLeftNavBarPanelView().getDefineNameListBox().getSelectedIndex();
                 if (selectedIndex != -1) {
                     final String selectedDefinitionID = cqlWorkspaceView.getCQLLeftNavBarPanelView().getDefineNameListBox().getValue(selectedIndex);

--- a/src/main/java/mat/client/cqlworkspace/CQLStandaloneWorkSpacePresenter.java
+++ b/src/main/java/mat/client/cqlworkspace/CQLStandaloneWorkSpacePresenter.java
@@ -2360,7 +2360,6 @@ public class CQLStandaloneWorkSpacePresenter extends AbstractCQLWorkspacePresent
         if (cqlWorkspaceView.getCQLLeftNavBarPanelView().getIsLoading()) {
             event.stopPropagation();
         } else {
-            showSearchBusyOnDoubleClick(true);
             cqlWorkspaceView.getCQLDefinitionsView().getDefineAceEditor().clearAnnotations();
             cqlWorkspaceView.getCQLDefinitionsView().getDefineAceEditor().removeAllMarkers();
             resetAceEditor(cqlWorkspaceView.getCQLDefinitionsView().getViewCQLAceEditor());
@@ -2368,9 +2367,9 @@ public class CQLStandaloneWorkSpacePresenter extends AbstractCQLWorkspacePresent
             cqlWorkspaceView.getCQLDefinitionsView().getReturnTypeTextBox().setText(EMPTY_STRING);
             cqlWorkspaceView.getCQLLeftNavBarPanelView().setIsDoubleClick(true);
             if (getIsPageDirty()) {
-                showSearchBusyOnDoubleClick(false);
                 showUnsavedChangesWarning();
             } else {
+                showSearchBusyOnDoubleClick(true);
                 int selectedIndex = cqlWorkspaceView.getCQLLeftNavBarPanelView().getDefineNameListBox().getSelectedIndex();
                 if (selectedIndex != -1) {
                     final String selectedDefinitionID = cqlWorkspaceView.getCQLLeftNavBarPanelView().getDefineNameListBox().getValue(selectedIndex);


### PR DESCRIPTION
<!--- In the *Title* field above, please provide the JIRA ticket number and a general summary of your changes -->
## Description
<!--- Describe your changes in detail -->
Issue: When the user has unsaved changes in Cql Definitions UI, and double clicks on another definition, a busy loading spinner is displayed and never removed.
Solution: When the page is dirty this spinner has to be set to false, but Carson commented it out. We could uncomment the statement where we set it to false, but I observed that this spinner does not have to be set to **true** at the beginning of '_definitionListBoxDoubleClickEvent_' method, the heavy work is done only if page is not dirty to started the spinner in the else part of the condition '_getIsPageDirty_'
## JIRA Ticket
<!--- Link to JIRA ticket -->
[MAT-3002](https://jira.cms.gov/browse/MAT-3002)
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
<!--- Put an `x` in the box when Screenshots are not relevant. Delete below line if adding screenshots. -->
- [ ] None applicable
