### PR TITLE
Default Patient-based indicator to No when option size is reduced

### DIFF
--- a/src/main/java/mat/client/measure/measuredetails/views/GeneralInformationView.java
+++ b/src/main/java/mat/client/measure/measuredetails/views/GeneralInformationView.java
@@ -406,7 +406,13 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
     }
 
     private void setPatientbasedIndicator() {
-        patientBasedInput.setSelectedIndex(generalInformationModel.isPatientBased() ? 1 : 0);
+        // Default to No if the option size is reduced, most likely from conversion to FHIR.
+        // Example, currently FHIR does not support patient-based CV, but QDM does.
+        if (patientBasedInput.getItemCount() == 2) {
+            patientBasedInput.setSelectedIndex(generalInformationModel.isPatientBased() ? 1 : 0);
+        } else {
+            patientBasedInput.setSelectedIndex(0);
+        }
     }
 
     private void addEventHandlers() {


### PR DESCRIPTION
## Description
Reduced Patient-based options happens when a QDM scoring type permitting both Patient-based and episode-of-care based is converted to FHIR where that same scoring type does not support both options.

Eventually, QDM and FHIR Scoring Types will have parity support for patient or non-patient based.

## JIRA Ticket
<!--- Link to JIRA ticket -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
<!--- Put an `x` in the box when Screenshots are not relevant. Delete below line if adding screenshots. -->
- [ ] None applicable
