### PR TITLE
ignoring dirty check if measure is deleted

### DIFF
--- a/src/main/java/mat/client/measure/measuredetails/MeasureDetailsPresenter.java
+++ b/src/main/java/mat/client/measure/measuredetails/MeasureDetailsPresenter.java
@@ -4,6 +4,7 @@ import com.google.gwt.event.shared.HandlerManager;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
+import mat.client.MainLayout;
 import mat.client.Mat;
 import mat.client.MatPresenter;
 import mat.client.MeasureHeading;
@@ -127,7 +128,7 @@ public class MeasureDetailsPresenter implements MatPresenter, MeasureDetailsObse
     private void setIsLoading() {
         measureDetailsView.clear();
         measureDetailsView.setReadOnly(true);
-        Mat.showLoadingMessage();
+        MainLayout.showLoadingMessage();
     }
 
     @Override
@@ -143,10 +144,10 @@ public class MeasureDetailsPresenter implements MatPresenter, MeasureDetailsObse
         panel.clear();
         panel.add(measureDetailsView.getWidget());
         showCompositeEdit = false;
-        if (goToComposite) {
+        if (Boolean.TRUE.equals(goToComposite)) {
             handleMenuItemClick(MeasureDetailsItems.COMPONENT_MEASURES);
         }
-        if (displaySuccessMessage) {
+        if (Boolean.TRUE.equals(displaySuccessMessage)) {
             measureDetailsView.displaySuccessMessage("Component Measures have been successfully updated");
         }
     }
@@ -203,7 +204,7 @@ public class MeasureDetailsPresenter implements MatPresenter, MeasureDetailsObse
 
     public boolean isDirty() {
         boolean isDirty = false;
-        if (!isReadOnly) {
+        if (!isReadOnly && !MatContext.get().isMeasureDeleted()) {
             if (showCompositeEdit) {
                 isDirty = componentMeasureDisplay.getComponentMeasureSearch().isDirty();
             } else if (measureDetailsView.getMeasureDetailsComponentModel() != null) {


### PR DESCRIPTION
<!--- In the *Title* field above, please provide the JIRA ticket number and a general summary of your changes -->
## Description
<!--- Describe your changes in detail -->
Added a condition for the dirty check to see if the measure is deleted. 
Tested with FHIR, QDM measures, and deleting stand-alone CQL libraries. 
## JIRA Ticket
<!--- Link to JIRA ticket -->
[MAT-3011](https://jira.cms.gov/browse/MAT-3011)
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
<!--- Put an `x` in the box when Screenshots are not relevant. Delete below line if adding screenshots. -->
- [ ] None applicable
