### PR TITLE
Check the ucum attribute is non-null during HR generation

### DIFF
--- a/src/main/java/mat/server/humanreadable/HumanReadableGenerator.java
+++ b/src/main/java/mat/server/humanreadable/HumanReadableGenerator.java
@@ -54,6 +54,8 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 @Component
 public class HumanReadableGenerator {
     private static final Log log = LogFactory.getLog(HumanReadableGenerator.class);
@@ -653,13 +655,24 @@ public class HumanReadableGenerator {
             populations = sortPopulations(populations);
 
             String displayName = "Population Criteria " + populationCriteriaNumber;
-            String scoreUnit = group.getAttributes().getNamedItem("ucum").getNodeValue().strip();
-            HumanReadablePopulationCriteriaModel populationCriteria = new HumanReadablePopulationCriteriaModel(displayName, populations, populationCriteriaNumber, scoreUnit);
+
+            HumanReadablePopulationCriteriaModel populationCriteria = new HumanReadablePopulationCriteriaModel(
+                    displayName,
+                    populations,
+                    populationCriteriaNumber,
+                    extractScoreUnit(group.getAttributes().getNamedItem("ucum")));
             groups.add(populationCriteria);
         }
 
         groups.sort(Comparator.comparing(HumanReadablePopulationCriteriaModel::getSequence));
         return groups;
+    }
+
+    private String extractScoreUnit(Node ucum) {
+        if (ucum != null && isNotBlank(ucum.getNodeValue().strip())) {
+            return ucum.getNodeValue().strip();
+        }
+        return "";
     }
 
     private void countSimilarPopulationsInGroup(int groupNo, String popTyp, XmlProcessor processor) {


### PR DESCRIPTION
## Description
Adding a null check on the ucum attribute in the Measure XML before calling `strip()` to prevent NPE. 

Extracting guard logic into its own method that returns either the ucum value as `scoreUnit` or an empty string, which Freemarker then ignores when generating the Human Readable since it has a length of `0`.

## JIRA Ticket
<!--- Link to JIRA ticket -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
<!--- Put an `x` in the box when Screenshots are not relevant. Delete below line if adding screenshots. -->
- [ ] None applicable
