### PR TITLE
Fixed issue with unlocking a measure after deleting

### DIFF
--- a/src/main/java/mat/client/MeasureComposerPresenter.java
+++ b/src/main/java/mat/client/MeasureComposerPresenter.java
@@ -211,11 +211,11 @@ public class MeasureComposerPresenter implements MatPresenter, MeasureHeading, E
 
     @Override
     public void beforeClosingDisplay() {
+        MatContext.get().getMeasureLockService().releaseMeasureLock();
         if (MatContext.get().isMeasureDeleted()) {
             MatContext.get().getCurrentMeasureInfo().setMeasureId("");
             MatContext.get().setMeasureDeleted(false);
         }
-        MatContext.get().getMeasureLockService().releaseMeasureLock();
         Command waitForUnlock = new Command() {
             @Override
             public void execute() {

--- a/src/main/java/mat/client/shared/MeasureLockService.java
+++ b/src/main/java/mat/client/shared/MeasureLockService.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package mat.client.shared;
 
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -8,32 +5,14 @@ import mat.client.event.MeasureSelectedEvent;
 import mat.client.measure.service.MeasureServiceAsync;
 import mat.client.measure.service.SaveMeasureResult;
 
-/**
- * The Class MeasureLockService.
- * 
- * @author vandavar This service class has api to setTheMeasureLock and release
- *         the MeasureLock whenever needed.
- */
 public class MeasureLockService {
-	
-	
-	/** The resetting lock. */
+
 	private boolean resettingLock = false;
-	
-	
-	
-	/*
-	 * Client side method to set the measureLock. 
-	 * This method makes RPC call by passing the current MeasureId.
-	 */
-	/**
-	 * Sets the measure lock.
-	 */
-	public void setMeasureLock(){
+
+	public void setMeasureLock() {
 		String currentMeasureId = getCurrentMeasureId();
-		if(currentMeasureId != null && !currentMeasureId.equals("")){
+		if (currentMeasureId != null && !currentMeasureId.equals("")) {
 			getMeasureService().updateLockedDate(currentMeasureId,getLoggedinUserId(), new AsyncCallback<SaveMeasureResult>() {
-				
 				@Override
 				public void onSuccess(SaveMeasureResult result) {
 					if(result.isSuccess())
@@ -46,20 +25,13 @@ public class MeasureLockService {
 					//Window.alert("Server error while setting the lockedoutDate");
 				}
 			});
-			}
+		}
 	}
-	
-	/*
-	 * Client side method to  release measureLock. 
-	 * This method makes RPC call by passing the current MeasureId.
-	 */
-	/**
-	 * Release measure lock.
-	 */
-	public void releaseMeasureLock(){
+
+	public void releaseMeasureLock() {
 		String currentMeasureId = getCurrentMeasureId();
 		MatContext.get().stopMeasureLockUpdate();
-		if(currentMeasureId != null && !currentMeasureId.equals("")){
+		if (currentMeasureId != null && !currentMeasureId.isEmpty() && !MatContext.get().isMeasureDeleted()) {
 			resettingLock = true;
 			getMeasureService().resetLockedDate(currentMeasureId,getLoggedinUserId(), new AsyncCallback<SaveMeasureResult>() {
 				
@@ -74,104 +46,59 @@ public class MeasureLockService {
 					//Window.alert("Server error while releasing the lockedoutDate");
 				}
 			});
-		}
+		} else {
+            resettingLock = true;
+        }
 	}
-	
-	/**
-	 * Checks if is resetting lock.
-	 * 
-	 * @return true, if is resetting lock
-	 */
-	public boolean isResettingLock(){
+
+	public boolean isResettingLock() {
 		return resettingLock;
 	}
-	
-	/**
-	 * Checks if is current measure locked.
-	 * 
-	 * @return true, if is current measure locked
-	 */
-	private boolean isCurrentMeasureLocked(){
-		if(getCurrentMeasureInfo() != null) {
+
+	private boolean isCurrentMeasureLocked() {
+		if (getCurrentMeasureInfo() != null) {
 			return getCurrentMeasureInfo().isLocked();
-		}else {
+		} else {
 			return false;
 		}
 	}
-	
-	/**
-	 * Check for edit permission.
-	 * 
-	 * @return true, if successful
-	 */
-	public boolean checkForEditPermission(){
-		if(isCurrentMeasureLocked()){
-		     if(!getLoggedinUserId().equalsIgnoreCase(getCurrentMeasureInfo().getLockedUserId()))
+
+	public boolean checkForEditPermission() {
+		if (isCurrentMeasureLocked()) {
+		     if (!getLoggedinUserId().equalsIgnoreCase(getCurrentMeasureInfo().getLockedUserId()))
 				return false;
-		}else if (!isCurrentMeasureEditable()){
+		} else if (!isCurrentMeasureEditable()){
 			    return false;
 		}
 		return true;
 	}
-	
-	/**
-	 * Gets the current measure id.
-	 * 
-	 * @return the current measure id
-	 */
-	private String getCurrentMeasureId(){
+
+	private String getCurrentMeasureId() {
 		return MatContext.get().getCurrentMeasureId();
 	}
-	
-	/**
-	 * Gets the loggedin user id.
-	 * 
-	 * @return the loggedin user id
-	 */
-	private String getLoggedinUserId(){
+
+	private String getLoggedinUserId() {
 		return MatContext.get().getLoggedinUserId();
 	}
-	
-	/**
-	 * Gets the measure service.
-	 * 
-	 * @return the measure service
-	 */
-	private MeasureServiceAsync getMeasureService(){
+
+	private MeasureServiceAsync getMeasureService() {
 		return MatContext.get().getMeasureService();
 	}
-	
-	/**
-	 * Gets the current measure info.
-	 * 
-	 * @return the current measure info
-	 */
-	private MeasureSelectedEvent getCurrentMeasureInfo(){
+
+	private MeasureSelectedEvent getCurrentMeasureInfo() {
 	   return MatContext.get().getCurrentMeasureInfo();
 	}
-	
-	/**
-	 * Checks if is current measure editable.
-	 * 
-	 * @return true, if is current measure editable
-	 */
-	private boolean isCurrentMeasureEditable(){
+
+	private boolean isCurrentMeasureEditable() {
 		return MatContext.get().isCurrentMeasureEditable();
 	}
-	
-	/**
-	 * Checks if is measure locked.
-	 * 
-	 * @param id
-	 *            the id
-	 */
-	public void isMeasureLocked(String id){
+
+	public void isMeasureLocked(String id) {
 		MatContext.get().getSynchronizationDelegate().setCheckingLock(true);
 		getMeasureService().isMeasureLocked(id, new AsyncCallback<Boolean>() {
 			
 			@Override
 			public void onSuccess(Boolean isLocked) {
-				
 				SynchronizationDelegate synchDel = MatContext.get().getSynchronizationDelegate();
 				synchDel.setMeasureIsLocked(isLocked);
 				synchDel.setCheckingLock(false);
@@ -185,5 +112,4 @@ public class MeasureLockService {
 			}
 		});
 	}
-	
 }


### PR DESCRIPTION
<!--- In the *Title* field above, please provide the JIRA ticket number and a general summary of your changes -->
## Description
<!--- Describe your changes in detail -->
The issue: When the measure details page is dirty and users tried to navigate, a confirmation warning is prompted, At this stage, if a user deletes the measure, it is deleted in DB, but few operations have to be performed before going back to measure grid. One of which is resetting the measure lock to null. This measure lock is used to make sure that only one user is editing the measure at any given point in time. 

- In this case, we are trying to reset the measure lock for a measure that is already deleted, which is causing the issue. 
Solution: A check has been added to verify if the measure is deleted, before resetting the measure lock.

## JIRA Ticket
<!--- Link to JIRA ticket -->
[MAT-3011](https://jira.cms.gov/browse/MAT-3011)
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
<!--- Put an `x` in the box when Screenshots are not relevant. Delete below line if adding screenshots. -->
- [ ] None applicable
