### PR TITLE
Additional Custom Error Pages

### DIFF
--- a/war/404.jsp
+++ b/war/404.jsp
@@ -19,7 +19,7 @@
 <div class="center">
     <div style="color: red"> 404: Page Not Found.</div>
     <div>Please contact your system administrator.</div>
-    <div>Click here to return to the <a href="Mat.html">Measure Authoring Tool</a></div>
+    <div>Click here to return to the <a href="https://www.emeasuretool.cms.gov/">Measure Authoring Tool</a></div>
 </div>
 
 </body>

--- a/war/WEB-INF/web.xml
+++ b/war/WEB-INF/web.xml
@@ -278,17 +278,32 @@
         </cookie-config>
     </session-config>
     <error-page>
+        <exception-type>java.lang.Throwable</exception-type>
+        <location>/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>401</error-code>
+        <location>/error.jsp</location>
+    </error-page>
+    <error-page>
         <error-code>403</error-code>
         <location>/Login.html</location>
     </error-page>
     <error-page>
-        <exception-type>java.lang.Throwable</exception-type>
-        <location>/error.jsp</location>
-    </error-page>
-
-    <error-page>
         <error-code>404</error-code>
         <location>/404.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>405</error-code>
+        <location>/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>500</error-code>
+        <location>/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>503</error-code>
+        <location>/error.jsp</location>
     </error-page>
 </web-app>
 

--- a/war/error.jsp
+++ b/war/error.jsp
@@ -17,7 +17,7 @@
 <div class="center">
     <div style="color: red"><%=response.getStatus() %>: Internal Server Error</div>
     <div>Please contact your system administrator.</div>
-    <div>Click here to return to the <a href="Mat.html">Measure Authoring Tool</a></div>
+    <div>Click here to return to the <a href="https://www.emeasuretool.cms.gov/">Measure Authoring Tool</a></div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Description
Set link to prod home page in error pages instead of using relative link to /Mat.html as it can readily fail if the user has navigated to an unsupported path.

Map common 400/500 errors to custom error page. Do not use the defaut tomcat error page as it includes stack trace and server version information that could be used by attackers.

## JIRA Ticket
<!--- Link to JIRA ticket -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
### Custom Error Page:
![Screen Shot 2021-06-10 at 11 36 01 AM](https://user-images.githubusercontent.com/56264529/121564602-a2c03300-c9e9-11eb-8506-5aad13bf9061.png)