### PR TITLE
Disable error report and server info on tomcat generated error pages

### DIFF
--- a/server.xml
+++ b/server.xml
@@ -164,8 +164,12 @@
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
                prefix="localhost_access_log" suffix=".txt"
                pattern="%h %l %u %t &quot;%r&quot; %s %b" />
-
-      </Host>
+        <!--
+          Do not show error report (custom error message and/or stack trace) is presented when an error occurs.
+          Do not include server information when an error occurs.
+        -->
+        <Valve className="org.apache.catalina.valves.ErrorReportValve" showReport="false" showServerInfo="false" />
+	</Host>
     </Engine>
   </Service>
 </Server>


### PR DESCRIPTION
## Description
Disable error report and server info on tomcat generated error pages.

## JIRA Ticket
<!--- Link to JIRA ticket -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
![Screen Shot 2021-06-10 at 11 26 10 AM](https://user-images.githubusercontent.com/56264529/121571429-000bb280-c9f1-11eb-8bb0-8b55e4e498be.png)