### PR TITLE
[MAT-3030] Ignore Defines not related to top level Population, SDE, or RAV defines

### DIFF
--- a/pmd.xml
+++ b/pmd.xml
@@ -12,8 +12,11 @@
    <!-- PMD prioritizes includes over excludes -->
    <include-pattern>.*/mat/server/hqmf/qdm_5_6/.*</include-pattern>
    <include-pattern>.*/mat/server/humanreadable/.*</include-pattern>
-   <include-pattern>.*/mat/server/service/impl/MeasurePackageServiceImpl.java</include-pattern>
    <include-pattern>.*/mat/server/CQLServiceImpl.java</include-pattern>
+   <include-pattern>.*/mat/server/service/impl/MeasurePackageServiceImpl.java</include-pattern>
+   <include-pattern>.*/mat/server/util/CQLUtil.java</include-pattern>
+   <include-pattern>.*/cqltoelm/MATCQLFilter.java</include-pattern>
+   <include-pattern>.*/cqltoelm/models/CQLGraph.java</include-pattern>
 
    <rule ref="category/java/bestpractices.xml">
       <exclude name="AbstractClassWithoutAbstractMethod"/>

--- a/src/main/java/cqltoelm/MATCQLFilter.java
+++ b/src/main/java/cqltoelm/MATCQLFilter.java
@@ -368,11 +368,7 @@ public class MATCQLFilter {
 
             Set<String> innerKeys = innerMap.keySet();
             for (String innerKey : innerKeys) {
-                if (flattenedMap.get(innerKey) == null) {
-                    flattenedMap.put(innerKey, new HashSet());
-                }
-
-                flattenedMap.get(innerKey).addAll(innerMap.get(innerKey));
+                flattenedMap.computeIfAbsent(innerKey, k -> new HashSet<>(innerMap.get(innerKey)));
             }
         }
 
@@ -459,27 +455,6 @@ public class MATCQLFilter {
         return expressionNameToCodeDataTypeMap;
     }
 
-    public static void main(String[] args) throws IOException {
-        File file = new File("C:\\Users\\jmeyer\\git\\test-cql\\test-0.0.000.cql");
-        String cqlString = cqlFileToString(file);
-        // you could also create a string like String cqlString = <cql library string here>
-        Map<String, String> childLibraries = new HashMap<>();
-        childLibraries.put("test2-0.0.000", cqlFileToString(new File("C:\\Users\\jmeyer\\git\\test-cql\\test2-0.0.000.cql")));
-        String[] formats = {"XML"};
-        CQLtoELM cqLtoELM = new CQLtoELM(cqlString, childLibraries);
-        cqLtoELM.doTranslation(true, "XML");
-        List<String> parentExpressions = new ArrayList<>();
-        parentExpressions.add("test");
-        if (!cqLtoELM.getErrors().isEmpty()) {
-            System.out.println(cqLtoELM.getErrors());
-            return;
-        }
-
-        MATCQLFilter filter = new MATCQLFilter(cqlString, cqLtoELM.getCqlLibraryMapping(), parentExpressions, cqLtoELM.getTranslator(), cqLtoELM.getTranslatedLibraries());
-        filter.filter();
-        System.out.println(filter);
-    }
-
     @Override
     public String toString() {
 
@@ -510,24 +485,6 @@ public class MATCQLFilter {
         builder.append("USED FUNCTIONS " + this.getUsedFunctions());
 
         return builder.toString();
-    }
-
-
-    /**
-     * Converts a cql file to a cql string
-     *
-     * @param file the file to convert
-     * @return the cql string
-     */
-    private static String cqlFileToString(File file) {
-        byte[] bytes = new byte[0];
-        try {
-            bytes = Files.readAllBytes(file.toPath());
-            return new String(bytes, "UTF-8");
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
-        }
     }
 
     public Map<String, Map<String, String>> getAllNamesToReturnTypeMap() {

--- a/src/main/java/cqltoelm/models/CQLGraph.java
+++ b/src/main/java/cqltoelm/models/CQLGraph.java
@@ -9,16 +9,9 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
-/**
- * Created by jmeyer on 1/9/2018.
- */
 public class CQLGraph {
 
-    private Map<String, Set<String>> graph = new HashMap<>();
-
-    public CQLGraph() {
-
-    }
+    private final Map<String, Set<String>> graph = new HashMap<>();
 
     public void addNode(String identifier) {
         Set<String> set = new HashSet<>();
@@ -50,12 +43,12 @@ public class CQLGraph {
         // if the String is in this set, it has been visited
         Set<String> visited = new HashSet<>();
 
-        Queue queue = new ArrayDeque<>();
+        Queue<String> queue = new ArrayDeque<>();
         visited.add(source); // mark source as visited.
         queue.add(source);
 
         while (!queue.isEmpty()) {
-            String currentNode = (String) queue.remove();
+            String currentNode = queue.remove();
             List<String> adjacentVerticies = new ArrayList<>(this.getAdjecencyList().get(currentNode));
 
             for (String adjacentNode : adjacentVerticies) {
@@ -74,8 +67,6 @@ public class CQLGraph {
 
         // if we never find the destination node...
         return false;
-
-
     }
 
     @Override
@@ -86,11 +77,9 @@ public class CQLGraph {
         }
 
         return builder.toString();
-
     }
 
     public Map<String, Set<String>> getAdjecencyList() {
         return graph;
     }
-
 }

--- a/src/main/java/mat/server/util/CQLUtil.java
+++ b/src/main/java/mat/server/util/CQLUtil.java
@@ -59,7 +59,7 @@ public class CQLUtil {
     /**
      * The Constant xPath.
      */
-    static final javax.xml.xpath.XPath xPath = XPathFactory.newInstance().newXPath();
+    static final javax.xml.xpath.XPath XPATH = XPathFactory.newInstance().newXPath();
 
     /**
      * The Constant logger.
@@ -82,7 +82,7 @@ public class CQLUtil {
         String xPathForFunctions = "//cqlfunction";
 
         try {
-            NodeList cqlDefinitions = (NodeList) xPath.evaluate(xPathForDefinitions, originalDoc.getDocumentElement(),
+            NodeList cqlDefinitions = (NodeList) XPATH.evaluate(xPathForDefinitions, originalDoc.getDocumentElement(),
                     XPathConstants.NODESET);
 
             for (int i = 0; i < cqlDefinitions.getLength(); i++) {
@@ -93,7 +93,7 @@ public class CQLUtil {
                 cqlArtifactHolder.addDefinitionIdentifier(name.replaceAll("\"", ""));
             }
 
-            NodeList cqlFunctions = (NodeList) xPath.evaluate(xPathForFunctions, originalDoc.getDocumentElement(),
+            NodeList cqlFunctions = (NodeList) XPATH.evaluate(xPathForFunctions, originalDoc.getDocumentElement(),
                     XPathConstants.NODESET);
 
             for (int i = 0; i < cqlFunctions.getLength(); i++) {
@@ -222,7 +222,7 @@ public class CQLUtil {
 
         String xPathForUnusedDefinitions = "//cqlLookUp//definition" + idXPathString;
 
-        NodeList unusedCQLDefNodeList = (NodeList) xPath.evaluate(xPathForUnusedDefinitions,
+        NodeList unusedCQLDefNodeList = (NodeList) XPATH.evaluate(xPathForUnusedDefinitions,
                 originalDoc.getDocumentElement(), XPathConstants.NODESET);
 
         for (int i = 0; i < unusedCQLDefNodeList.getLength(); i++) {
@@ -252,7 +252,7 @@ public class CQLUtil {
 
         String xPathForUnusedFunctions = "//cqlLookUp//function" + idXPathString;
 
-        NodeList unusedCqlFuncNodeList = (NodeList) xPath.evaluate(xPathForUnusedFunctions,
+        NodeList unusedCqlFuncNodeList = (NodeList) XPATH.evaluate(xPathForUnusedFunctions,
                 originalDoc.getDocumentElement(), XPathConstants.NODESET);
         for (int i = 0; i < unusedCqlFuncNodeList.getLength(); i++) {
             Node current = unusedCqlFuncNodeList.item(i);
@@ -281,7 +281,7 @@ public class CQLUtil {
 
         String xPathForUnusedValuesets = "//cqlLookUp//valueset" + nameXPathString;
 
-        NodeList unusedCqlValuesetNodeList = (NodeList) xPath.evaluate(xPathForUnusedValuesets,
+        NodeList unusedCqlValuesetNodeList = (NodeList) XPATH.evaluate(xPathForUnusedValuesets,
                 originalDoc.getDocumentElement(), XPathConstants.NODESET);
 
         for (int i = 0; i < unusedCqlValuesetNodeList.getLength(); i++) {
@@ -310,7 +310,7 @@ public class CQLUtil {
 
         String xPathForUnusedCodes = "//cqlLookUp//code" + nameXPathString;
 
-        NodeList unusedCqlCodesNodeList = (NodeList) xPath.evaluate(xPathForUnusedCodes, originalDoc.getDocumentElement(), XPathConstants.NODESET);
+        NodeList unusedCqlCodesNodeList = (NodeList) XPATH.evaluate(xPathForUnusedCodes, originalDoc.getDocumentElement(), XPathConstants.NODESET);
         for (int i = 0; i < unusedCqlCodesNodeList.getLength(); i++) {
             Node current = unusedCqlCodesNodeList.item(i);
             Node parent = current.getParentNode();
@@ -329,7 +329,7 @@ public class CQLUtil {
 
         // find all used codeSystemNames
         String xPathForCodesystemNames = "//cqlLookUp/codes/code";
-        NodeList codeSystemNameList = (NodeList) xPath.evaluate(xPathForCodesystemNames,
+        NodeList codeSystemNameList = (NodeList) XPATH.evaluate(xPathForCodesystemNames,
                 originalDoc.getDocumentElement(), XPathConstants.NODESET);
 
         String nameXPathString = "";
@@ -342,7 +342,7 @@ public class CQLUtil {
         }
 
         String xPathForUnusedCodeSystems = "//cqlLookUp/codeSystems/codeSystem" + nameXPathString;
-        NodeList unusedCqlCodeSystemNodeList = (NodeList) xPath.evaluate(xPathForUnusedCodeSystems,
+        NodeList unusedCqlCodeSystemNodeList = (NodeList) XPATH.evaluate(xPathForUnusedCodeSystems,
                 originalDoc.getDocumentElement(), XPathConstants.NODESET);
 
         for (int i = 0; i < unusedCqlCodeSystemNodeList.getLength(); i++) {
@@ -371,7 +371,7 @@ public class CQLUtil {
 
         String xPathForUnusedParameters = "//cqlLookUp//parameter" + nameXPathString;
 
-        NodeList unusedCqlParameterNodeList = (NodeList) xPath.evaluate(xPathForUnusedParameters,
+        NodeList unusedCqlParameterNodeList = (NodeList) XPATH.evaluate(xPathForUnusedParameters,
                 originalDoc.getDocumentElement(), XPathConstants.NODESET);
         for (int i = 0; i < unusedCqlParameterNodeList.getLength(); i++) {
             Node current = unusedCqlParameterNodeList.item(i);
@@ -387,7 +387,7 @@ public class CQLUtil {
         String includeLibrariesXPath = "//cqlLookUp/includeLibrarys";
 
         try {
-            Node node = (Node) xPath.evaluate(includeLibrariesXPath, originalDoc.getDocumentElement(), XPathConstants.NODE);
+            Node node = (Node) XPATH.evaluate(includeLibrariesXPath, originalDoc.getDocumentElement(), XPathConstants.NODE);
             if (node != null) {
                 NodeList childNodes = node.getChildNodes();
                 for (int i = 0; i < childNodes.getLength(); i++) {
@@ -446,7 +446,7 @@ public class CQLUtil {
         }
 
         String xPathForUnusedIncludes = "//cqlLookUp//includeLibrarys/includeLibrary" + nameXPathString;
-        NodeList unusedCqlIncludeNodeList = (NodeList) xPath.evaluate(xPathForUnusedIncludes,
+        NodeList unusedCqlIncludeNodeList = (NodeList) XPATH.evaluate(xPathForUnusedIncludes,
                 originalDoc.getDocumentElement(), XPathConstants.NODESET);
         for (int i = 0; i < unusedCqlIncludeNodeList.getLength(); i++) {
             Node current = unusedCqlIncludeNodeList.item(i);
@@ -543,7 +543,9 @@ public class CQLUtil {
 
         for (CQLIncludeLibrary cqlIncludeLibrary : cqlIncludeLibraries) {
             CQLModel includeCqlModel = generateCQLIncludeModelMap(cqlIncludeLibrary, cqlLibNameMap, cqlIncludeModelMap, cqlLibraryDAO);
-            if (includeCqlModel == null) continue;
+            if (includeCqlModel == null) {
+                continue;
+            }
             getCQLIncludeMaps(includeCqlModel, cqlLibNameMap, includeCqlModel.getIncludedLibrarys(), cqlLibraryDAO, cqlIncludeLibrary);
         }
     }
@@ -558,7 +560,9 @@ public class CQLUtil {
         for (CQLIncludeLibrary cqlIncludeLibrary : cqlIncludeLibraries) {
             cqlIncludeLibrary.setIsComponent(parentCQLIncludeLibrary.getIsComponent());
             CQLModel includeCqlModel = generateCQLIncludeModelMap(cqlIncludeLibrary, cqlLibNameMap, cqlIncludeModelMap, cqlLibraryDAO);
-            if (includeCqlModel == null) continue;
+            if (includeCqlModel == null) {
+                continue;
+            }
             getCQLIncludeMaps(includeCqlModel, cqlLibNameMap, includeCqlModel.getIncludedLibrarys(), cqlLibraryDAO, cqlIncludeLibrary);
         }
     }
@@ -685,20 +689,12 @@ public class CQLUtil {
 
         }
 
-
         cqlError.setErrorMessage(cte.getMessage());
         cqlError.setSeverity(cte.getSeverity().toString());
 
-
-        initializeErrorsListForLibraryIfNeeded(libraryToErrorsMap, libraryName);
+        libraryToErrorsMap.computeIfAbsent(libraryName, k -> new ArrayList<>());
         libraryToErrorsMap.get(libraryName).add(cqlError);
         errors.add(cqlError);
-    }
-
-    private static void initializeErrorsListForLibraryIfNeeded(Map<String, List<CQLError>> libraryToErrorsMap, String libraryName) {
-        if (libraryToErrorsMap.get(libraryName) == null) {
-            libraryToErrorsMap.put(libraryName, new ArrayList<>());
-        }
     }
 
     /**
@@ -714,7 +710,7 @@ public class CQLUtil {
         CQLObject cqlObject = new CQLObject();
         if (cqlToElm != null && cqlToElm.getErrors().isEmpty()) {
             String parentLibraryString = cqlToElm.getParentCQLLibraryString();
-
+            // expression List => population/sde/rav defines and functions
             MATCQLFilter cqlFilter = new MATCQLFilter(parentLibraryString, cqlToElm.getCqlLibraryMapping(), exprList, cqlToElm.getTranslator(), cqlToElm.getTranslatedLibraries());
 
             try {
@@ -750,7 +746,6 @@ public class CQLUtil {
 
                 cqlObject.getCqlFunctionObjectList().add(expression);
             }
-
 
             for (CQLParameter parameter : cqlModel.getCqlParameters()) {
                 String parameterName = parameter.getName();


### PR DESCRIPTION
## Description
When we swapped out the SmimpleXML for the Measure XML as the basis for the Human Readable we lost the define filtering done when generating the SimpleXML (from the Measure XML), which was too restrictive for the Human Readable, but was expected by the Human Readable Generator.
    
This introduces a simpler filter to ensure only top level Population, Supplemental Data Elements (SDE), and Risk Adjustment Variables (RAV) and their descendants are displayed in the HR, thereby matching the filtering done to the CQL.

Minor changes:
- Clean up utility classes
- Add modified classes to pmd config

## JIRA Ticket
[MAT-3030](https://jira.cms.gov/browse/MAT-3030)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
<!--- Put an `x` in the box when Screenshots are not relevant. Delete below line if adding screenshots. -->
- [x] None applicable
