### PR TITLE
[MAT-3042] Disable Save/Cancel during save operation for Draft/Clone

### DIFF
--- a/src/main/java/mat/client/measure/ManageMeasurePresenter.java
+++ b/src/main/java/mat/client/measure/ManageMeasurePresenter.java
@@ -817,11 +817,15 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
         MeasureCloningRemoteServiceAsync measureCloningService = GWT.create(MeasureCloningRemoteService.class);
 
         if (isValid(currentDetails, false)) {
+            ((Button) detailDisplay.getSaveButton()).setEnabled(false);
+            ((Button) detailDisplay.getCancelButton()).setEnabled(false);
             measureCloningService.cloneExistingMeasure(currentDetails, new AsyncCallback<ManageMeasureSearchModel.Result>() {
                 @Override
                 public void onFailure(Throwable caught) {
                     detailDisplay.getErrorMessageDisplay().createAlert(caught.getLocalizedMessage());
                     MatContext.get().recordTransactionEvent(null, null, null, UNHANDLED_EXCEPTION + caught.getLocalizedMessage(), 0);
+                    ((Button) detailDisplay.getSaveButton()).setEnabled(true);
+                    ((Button) detailDisplay.getCancelButton()).setEnabled(true);
                 }
 
                 @Override
@@ -848,12 +852,16 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
         searchDisplay.resetMessageDisplay();
         MeasureCloningRemoteServiceAsync measureCloningService = GWT.create(MeasureCloningRemoteService.class);
         if (isValidCompositeMeasure(currentCompositeMeasureDetails)) {
+            ((Button) detailDisplay.getSaveButton()).setEnabled(false);
+            ((Button) detailDisplay.getCancelButton()).setEnabled(false);
             measureCloningService.draftExistingMeasure(currentCompositeMeasureDetails, new AsyncCallback<ManageMeasureSearchModel.Result>() {
                 @Override
                 public void onFailure(Throwable caught) {
                     setSearchingBusy(false);
                     compositeDetailDisplay.getErrorMessageDisplay().createAlert(caught.getLocalizedMessage());
                     MatContext.get().recordTransactionEvent(null, null, null, UNHANDLED_EXCEPTION + caught.getLocalizedMessage(), 0);
+                    ((Button) detailDisplay.getSaveButton()).setEnabled(true);
+                    ((Button) detailDisplay.getCancelButton()).setEnabled(true);
                 }
 
                 @Override
@@ -885,12 +893,16 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
 
         searchDisplay.resetMessageDisplay();
         if (isValid(currentDetails, true)) {
+            ((Button) detailDisplay.getSaveButton()).setEnabled(false);
+            ((Button) detailDisplay.getCancelButton()).setEnabled(false);
             MeasureCloningRemoteServiceAsync measureCloningService = GWT.create(MeasureCloningRemoteService.class);
             measureCloningService.draftExistingMeasure(currentDetails, new AsyncCallback<ManageMeasureSearchModel.Result>() {
                 @Override
                 public void onFailure(Throwable caught) {
                     detailDisplay.getErrorMessageDisplay().createAlert(caught.getLocalizedMessage());
                     MatContext.get().recordTransactionEvent(null, null, null, UNHANDLED_EXCEPTION + caught.getLocalizedMessage(), 0);
+                    ((Button) detailDisplay.getSaveButton()).setEnabled(true);
+                    ((Button) detailDisplay.getCancelButton()).setEnabled(true);
                 }
 
                 @Override
@@ -2301,6 +2313,8 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
         searchDisplay.getCreateCompositeMeasureButton().setEnabled(!busy);
         searchDisplay.getCustomFilterCheckBox().setEnabled(!busy);
         searchDisplay.getMeasureSearchFilterWidget().getAdvancedSearchPanel().getAdvanceSearchAnchor().setEnabled(!busy);
+        ((Button) detailDisplay.getSaveButton()).setEnabled(!busy);
+        ((Button) detailDisplay.getCancelButton()).setEnabled(!busy);
     }
 
     private void toggleLoadingMessage(boolean busy) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Occasionally, a user can multi-press the save button and generate multiple draft/clones. Most of the time, validation kicks in and rejects the extra requests.

Disable the save and cancel buttons on save click until the operation completes.

## JIRA Ticket
[MAT-3042](https://jira.cms.gov/browse/MAT-3042)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
<!--- Put an `x` in the box when Screenshots are not relevant. Delete below line if adding screenshots. -->
- [ ] None applicable
