### PR TITLE
[MAT-3054] Permit special characters in DRCs validation and provide more descriptive error messages

### DIFF
--- a/src/main/java/mat/client/cqlworkspace/AbstractCQLWorkspacePresenter.java
+++ b/src/main/java/mat/client/cqlworkspace/AbstractCQLWorkspacePresenter.java
@@ -2136,6 +2136,12 @@ public abstract class AbstractCQLWorkspacePresenter {
                 Mat.hideUMLSActive(true);
                 MatContext.get().setUMLSLoggedIn(false);
                 break;
+            case VsacApiResult.VSAC_SERVER_ERROR:
+                message = MessageDelegate.getVsacServerError();
+                break;
+            case VsacApiResult.VSAC_NOT_FOUND_ERROR:
+                message = MessageDelegate.getVsacCodeNotFound();
+                break;
             default:
                 message = "";
         }

--- a/src/main/java/mat/client/shared/MessageDelegate.java
+++ b/src/main/java/mat/client/shared/MessageDelegate.java
@@ -171,6 +171,8 @@ public class MessageDelegate {
     private static final String VALIDATION_MSG_ELEMENT_WITHOUT_VSAC = "Please enter value set name.";
     private static final String VALUE_SET_DATE_INVALID = "Value Set Package Date is not a valid date.";
     private static final String VSAC_RETRIEVE_FAILED = "Unable to retrieve from VSAC. Please check the data and try again.";
+    private static final String VSAC_CODE_NOT_FOUND = "Code Not found in VSAC.";
+    private static final String VSAC_SERVER_ERROR = "Your request to VSAC has errored out. Please attempt your retrieve again. If the problem persists, please contact the MAT Support Desk.";
     private static final String VSAC_RETRIEVE_TIMEOUT = "Your request to VSAC has timed-out. Please attempt your retrieve again. If the problem persists, please contact the MAT Support Desk.";
     private static final String COMMENT_ADDED_SUCCESSFULLY = "Comment Changes Added.";
     private static final String COMPARISON_DILOAG_BOX_ERROR_DISPLAY = "Please enter Quantity field.";
@@ -208,6 +210,14 @@ public class MessageDelegate {
     private static final String MEASURE_TYPE_REQUIRED = "Please enter the Measure Type prior to packaging.";
     private static final String MEASURE_POPULATION_BASIS = "Please select the measure's Population basis prior to packaging.";
     private static final String MEASURE_DESCRIPTION_UNDERSCORE = "Measure name must not contain '_' (underscore).";
+
+    public static String getVsacCodeNotFound() {
+        return VSAC_CODE_NOT_FOUND;
+    }
+
+    public static String getVsacServerError() {
+        return VSAC_SERVER_ERROR;
+    }
 
     public static String getUnableToVerifyHarpUser() {
         return UNABLE_TO_VERIFY_HARP_USER;

--- a/src/main/java/mat/client/umls/service/VsacApiResult.java
+++ b/src/main/java/mat/client/umls/service/VsacApiResult.java
@@ -36,7 +36,11 @@ public class VsacApiResult implements IsSerializable {
 	public static final int VSAC_UNAUTHORIZED_ERROR = 6;
 
 	public static final int INVALID_OID = 0;
-	
+
+	public static final int VSAC_NOT_FOUND_ERROR = 98;
+
+	public static final int VSAC_SERVER_ERROR = 99;
+
 	/** The failure reason. */
 	private int failureReason;
 	

--- a/src/main/java/mat/server/VSACApiServImpl.java
+++ b/src/main/java/mat/server/VSACApiServImpl.java
@@ -467,6 +467,13 @@ public class VSACApiServImpl implements VSACApiService {
                                 vsacResponseResult.getXmlPayLoad());
                         result.setDirectReferenceCode(referenceCode);
                         result.setSuccess(true);
+                    } else if(vsacResponseResult.isFailResponse()) {
+                        result.setSuccess(false);
+                        if (vsacResponseResult.getFailReason() == BasicResponse.REQUEST_NOT_FOUND) {
+                            result.setFailureReason(VsacApiResult.VSAC_NOT_FOUND_ERROR);
+                        } else if (vsacResponseResult.getFailReason() == BasicResponse.SERVER_ERROR) {
+                            result.setFailureReason(VsacApiResult.VSAC_SERVER_ERROR);
+                        }
                     }
 
                 } else {

--- a/src/main/java/mat/server/service/cql/FhirCqlParserService.java
+++ b/src/main/java/mat/server/service/cql/FhirCqlParserService.java
@@ -16,6 +16,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import javax.servlet.http.HttpSession;
@@ -172,7 +173,11 @@ public class FhirCqlParserService implements FhirCqlParser {
         } catch (HttpClientErrorException e) {
             log.error("HttpClientErrorException", e);
             throw new MatRuntimeException(e);
-        } finally {
+        } catch (HttpServerErrorException e) {
+            log.error("HttpServerErrorException", e);
+            throw new MatRuntimeException(e);
+        }
+        finally {
             if (response != null && response.getHeaders().containsKey(REFRESHED_GRANTING_TICKET)) {
                 setRefreshedTicket(response.getHeaders().getFirst(REFRESHED_GRANTING_TICKET));
             }

--- a/src/main/java/mat/shared/CQLModelValidator.java
+++ b/src/main/java/mat/shared/CQLModelValidator.java
@@ -23,7 +23,7 @@ public class CQLModelValidator {
      * The code regex expression.
      */
     private final String CODE_REGEX_EXPRESSION = "^(CODE:/CodeSystem/)([^/]*)" +
-            "(/Version/)([^/]*)(/Code/)([^/]*)(/Info)$";
+            "(/Version/)([^/]*)(/Code/)([\\S]*)(/Info)$";
 
     /**
      * The code reg exp.

--- a/src/main/java/mat/vsacmodel/BasicResponse.java
+++ b/src/main/java/mat/vsacmodel/BasicResponse.java
@@ -13,6 +13,8 @@ import java.util.List;
 public class BasicResponse implements Serializable {
     public static final int REQUEST_TIMEDOUT = 3;
     public static final int REQUEST_FAILED = 4;
+    public static final int REQUEST_NOT_FOUND = 98;
+    public static final int SERVER_ERROR = 99;
 
     private String xmlPayLoad;
     private List<String> pgmRels;


### PR DESCRIPTION
## Description
Preventing `/` chars was blocking users from using valid DRCs (i.e. kg/m2). Opting to permit any non-whitespace characters instead since the UCUM Code System uses `%`, `{`, `_`, and other special chars.

Adding more descriptive error messages for VSAC 404 and 5XX responses on code lookup requests. The MAT uses int values to map response errors to frontend error displays. To avoid mapping conflicts, the new VSAC error messages map to values >90.

#### NOTE:
VSAC had to update their service to correctly parse codes with `/`. Codes with `%` and `*`, will continue to be a problem until VSAC applies a long term fix.


## JIRA Ticket
[MAT-3054](https://jira.cms.gov/browse/MAT-3054)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
<!--- Put an `x` in the box when Screenshots are not relevant. Delete below line if adding screenshots. -->
- [x] None applicable
