### PR TITLE
[MAT-3098] Re-enable Save/Cancel Button on Error

### DIFF
--- a/src/main/java/mat/client/measure/ManageMeasurePresenter.java
+++ b/src/main/java/mat/client/measure/ManageMeasurePresenter.java
@@ -687,9 +687,12 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
                     } else {
                         detailDisplay.getErrorMessageDisplay().createAlert(displayErrorMessage(result));
                     }
+                    // Re-enable buttons after displaying error message.
+                    setSearchingBusy(false);
                 }
             });
         } else {
+            // else clause is preventing the buttons from being re-enabled when creation was successful.
             setSearchingBusy(false);
         }
     }


### PR DESCRIPTION
## Description
The Save/Cancel buttons were remaining disabled whenever a round-trip validation check returned a failure (i.e. Library name already exists in DB).

Re-enable buttons after displaying the error message ensuring they are disabled whenever the validations are successful and the Library is created.

## JIRA Ticket
[MAT-3098](https://jira.cms.gov/browse/MAT-3098)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
<!--- Put an `x` in the box when Screenshots are not relevant. Delete below line if adding screenshots. -->
- [ ] None applicable
