### PR TITLE
Condition to check for FhirHelpers Revision number

### DIFF
--- a/src/main/java/mat/client/cqlworkspace/CQLMeasureWorkSpacePresenter.java
+++ b/src/main/java/mat/client/cqlworkspace/CQLMeasureWorkSpacePresenter.java
@@ -304,7 +304,9 @@ public class CQLMeasureWorkSpacePresenter extends AbstractCQLWorkspacePresenter 
                 CQLIncludeLibrary incLibrary = new CQLIncludeLibrary();
                 incLibrary.setAliasName(aliasName);
                 incLibrary.setCqlLibraryId(cqlLibraryDataSetObject.getId());
-                String versionValue = cqlLibraryDataSetObject.getVersion().replace("v", EMPTY_STRING) + "." + "000";
+                // All versioned libraries should have '000' as revision number but FHIRHelpers library has '001'.
+                String versionValue = cqlLibraryDataSetObject.getVersion().replace("v", EMPTY_STRING) + "."
+                        + (cqlLibraryDataSetObject.getRevisionNumber().equals("1") ? "001" : "000");
                 incLibrary.setVersion(versionValue);
                 incLibrary.setCqlLibraryName(cqlLibraryDataSetObject.getCqlName());
                 incLibrary.setQdmVersion(cqlLibraryDataSetObject.getQdmVersion());

--- a/src/main/java/mat/client/cqlworkspace/CQLMeasureWorkSpacePresenter.java
+++ b/src/main/java/mat/client/cqlworkspace/CQLMeasureWorkSpacePresenter.java
@@ -58,7 +58,6 @@ import mat.shared.StringUtility;
 import mat.shared.cql.error.InvalidLibraryException;
 import mat.shared.model.util.MeasureDetailsUtil;
 import org.gwtbootstrap3.client.ui.constants.ValidationState;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -306,7 +305,7 @@ public class CQLMeasureWorkSpacePresenter extends AbstractCQLWorkspacePresenter 
                 incLibrary.setCqlLibraryId(cqlLibraryDataSetObject.getId());
                 // All versioned libraries should have '000' as revision number but FHIRHelpers library has '001'.
                 String versionValue = cqlLibraryDataSetObject.getVersion().replace("v", EMPTY_STRING) + "."
-                        + (cqlLibraryDataSetObject.getRevisionNumber().equals("1") ? "001" : "000");
+                        + StringUtility.padLeftZeros(cqlLibraryDataSetObject.getRevisionNumber(), 3);
                 incLibrary.setVersion(versionValue);
                 incLibrary.setCqlLibraryName(cqlLibraryDataSetObject.getCqlName());
                 incLibrary.setQdmVersion(cqlLibraryDataSetObject.getQdmVersion());

--- a/src/main/java/mat/client/cqlworkspace/CQLStandaloneWorkSpacePresenter.java
+++ b/src/main/java/mat/client/cqlworkspace/CQLStandaloneWorkSpacePresenter.java
@@ -739,7 +739,9 @@ public class CQLStandaloneWorkSpacePresenter extends AbstractCQLWorkspacePresent
                     CQLIncludeLibrary incLibrary = new CQLIncludeLibrary();
                     incLibrary.setAliasName(aliasName);
                     incLibrary.setCqlLibraryId(cqlLibraryDataSetObject.getId());
-                    String versionValue = cqlLibraryDataSetObject.getVersion().replace("v", EMPTY_STRING) + "." + "000";
+                    // All versioned libraries should have '000' as revision number but FHIRHelpers library has '001'.
+                    String versionValue = cqlLibraryDataSetObject.getVersion().replace("v", EMPTY_STRING) + "."
+                            + (cqlLibraryDataSetObject.getRevisionNumber().equals("1") ? "001" : "000");
                     incLibrary.setVersion(versionValue);
                     incLibrary.setCqlLibraryName(cqlLibraryDataSetObject.getCqlName());
                     incLibrary.setQdmVersion(cqlLibraryDataSetObject.getQdmVersion());

--- a/src/main/java/mat/client/cqlworkspace/CQLStandaloneWorkSpacePresenter.java
+++ b/src/main/java/mat/client/cqlworkspace/CQLStandaloneWorkSpacePresenter.java
@@ -741,7 +741,7 @@ public class CQLStandaloneWorkSpacePresenter extends AbstractCQLWorkspacePresent
                     incLibrary.setCqlLibraryId(cqlLibraryDataSetObject.getId());
                     // All versioned libraries should have '000' as revision number but FHIRHelpers library has '001'.
                     String versionValue = cqlLibraryDataSetObject.getVersion().replace("v", EMPTY_STRING) + "."
-                            + (cqlLibraryDataSetObject.getRevisionNumber().equals("1") ? "001" : "000");
+                            + StringUtility.padLeftZeros(cqlLibraryDataSetObject.getRevisionNumber(), 3);
                     incLibrary.setVersion(versionValue);
                     incLibrary.setCqlLibraryName(cqlLibraryDataSetObject.getCqlName());
                     incLibrary.setQdmVersion(cqlLibraryDataSetObject.getQdmVersion());

--- a/src/main/java/mat/shared/StringUtility.java
+++ b/src/main/java/mat/shared/StringUtility.java
@@ -148,4 +148,17 @@ public class StringUtility {
 		return html.replaceAll("&", "&amp;").replaceAll("<", "&lt;")
 				.replaceAll(">", "&gt;").replaceAll("\"", "&quot;").replaceAll("'", "&#39;");
 	}
+
+    public static String padLeftZeros(String inputString, int length) {
+        if (inputString.length() >= length) {
+            return inputString;
+        }
+        StringBuilder sb = new StringBuilder();
+        while (sb.length() < length - inputString.length()) {
+            sb.append('0');
+        }
+        sb.append(inputString);
+
+        return sb.toString();
+    }
 }

--- a/super-dev-mode/pom.xml
+++ b/super-dev-mode/pom.xml
@@ -94,12 +94,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty.aggregate</groupId>
-            <artifactId>jetty-all</artifactId>
-            <version>9.4.24.v20191120</version>
-            <type>pom</type>
-        </dependency>
-        <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>cql</artifactId>
             <version>${cqframework.version}</version>
@@ -128,7 +122,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.5.1</version>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>info.cqframework</groupId>
@@ -191,7 +195,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.7</version>
+            <version>3.11</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
@@ -223,6 +227,16 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-quartz</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -240,6 +254,11 @@
                 <exclusion>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+                <!-- exclude jackson-databind in favor of newer version -->
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -271,7 +290,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.4.20</version>
+            <version>2.4.21</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
@@ -373,7 +392,7 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
-            <version>4.1.1</version>
+            <version>4.2.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>ch.qos.logback</groupId>
@@ -388,12 +407,12 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
-            <version>2.3.0</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>30.0-jre</version>
+            <version>30.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -430,7 +449,7 @@
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd</artifactId>
-            <version>6.29.0</version>
+            <version>6.31.0</version>
             <type>pom</type>
             <exclusions>
                 <exclusion>
@@ -492,14 +511,13 @@
             <!-- this is needed or IntelliJ gives junit.jar or junit-platform-launcher:1.3.2 not found errors -->
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.5.2</version>
+            <version>1.7.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <!-- this is needed or IntelliJ gives junit.jar or junit-platform-launcher:1.3.2 not found errors -->
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-runner</artifactId>
-            <version>1.7.0</version>
+            <version>1.7.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -572,37 +590,13 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.10</version>
-            <scope>provided</scope>
+            <version>1.18.18</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-structures-r4</artifactId>
             <version>${hapi-fhir-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>info.cqframework</groupId>
-            <artifactId>cql-to-elm</artifactId>
-            <version>1.5.2</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>antlr4-runtime</artifactId>
-            <version>4.9.1</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>info.cqframework</groupId>
-            <artifactId>elm</artifactId>
-            <version>1.5.2</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>info.cqframework</groupId>
-            <artifactId>elm</artifactId>
-            <version>1.5.2</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Description
All versioned libraries should have '000' as revision number but for FHIRHelpers library the revision number is set to '001' probably a corrupted data issue. So had a condition to check for a particular revision number while including this library using helper UI. 

Also updated Super-dev-mode pom file with the latest pom, so that both the pom files will be in sync. 

## JIRA Ticket
[MAT-3114](https://jira.cms.gov/browse/MAT-3114)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
<!--- Put an `x` in the box when Screenshots are not relevant. Delete below line if adding screenshots. -->
- [ ] None applicable
