### PR TITLE
[MAT-3226] FHIR HR: Include external Defines/Functions

### DIFF
--- a/src/main/java/mat/server/humanreadable/HumanReadableGenerator.java
+++ b/src/main/java/mat/server/humanreadable/HumanReadableGenerator.java
@@ -156,8 +156,8 @@ public class HumanReadableGenerator {
                 model.setSupplementalDataElements(getSupplementalDataElements(processor));
                 model.setRiskAdjustmentVariables(getRiskAdjustmentVariables(processor));
 
-                model.setDefinitions(getDefinitionsQDM(processor, includedLibraryXmlProcessors, cqlResult, usedCQLArtifactHolder));
-                model.setFunctions(getFunctionsQDM(processor, includedLibraryXmlProcessors, cqlResult, usedCQLArtifactHolder));
+                model.setDefinitions(getDefinitions(processor, includedLibraryXmlProcessors, cqlResult, usedCQLArtifactHolder));
+                model.setFunctions(getFunctions(processor, includedLibraryXmlProcessors, cqlResult, usedCQLArtifactHolder));
 
                 if (cqlModel.isFhir()) {
                     // Retrieve Terminology info from microservices/HAPI.
@@ -291,7 +291,7 @@ public class HumanReadableGenerator {
         return signature;
     }
 
-    private List<HumanReadableExpressionModel> getDefinitionsQDM(XmlProcessor parentLibraryProcessor, Map<String, XmlProcessor> includedLibraryXmlProcessors, SaveUpdateCQLResult cqlResult, CQLArtifactHolder usedCQLArtifactHolder) {
+    private List<HumanReadableExpressionModel> getDefinitions(XmlProcessor parentLibraryProcessor, Map<String, XmlProcessor> includedLibraryXmlProcessors, SaveUpdateCQLResult cqlResult, CQLArtifactHolder usedCQLArtifactHolder) {
         List<HumanReadableExpressionModel> definitions = new ArrayList<>();
         List<String> usedDefinitions = cqlResult.getUsedCQLArtifacts().getUsedCQLDefinitions();
         List<String> definitionsList = new ArrayList<>(usedCQLArtifactHolder.getCqlDefFromPopSet());
@@ -317,28 +317,7 @@ public class HumanReadableGenerator {
         return definitions;
     }
 
-    private List<HumanReadableExpressionModel> getDefinitionsFHIR(CQLModel cqlModel, XmlProcessor parentLibraryProcessor, Map<String, XmlProcessor> includedLibraryXmlProcessors) {
-        List<HumanReadableExpressionModel> definitions = new ArrayList<>();
-        cqlModel.getDefinitionList().stream().
-                sorted((d1, d2) -> String.CASE_INSENSITIVE_ORDER.compare(d1.getName(), d2.getName())).
-                forEach(d -> {
-                    String name = d.getName();
-                    String statementIdentifier = d.getName();
-                    XmlProcessor currentProcessor = parentLibraryProcessor;
-                    String[] arr = name.split(Pattern.quote("|"));
-                    if (arr.length == 3) {
-                        name = arr[2];
-                        statementIdentifier = arr[1] + "." + arr[2];
-                        currentProcessor = includedLibraryXmlProcessors.get(arr[0] + "|" + arr[1]);
-                    }
-                    HumanReadableExpressionModel expression = new HumanReadableExpressionModel(statementIdentifier,
-                            getLogicStringFromXMLByName(name, CQLDEFINITION, currentProcessor));
-                    definitions.add(expression);
-                });
-        return definitions;
-    }
-
-    private List<HumanReadableExpressionModel> getFunctionsQDM(XmlProcessor parentLibraryProcessor, Map<String, XmlProcessor> includedLibraryXmlProcessors, SaveUpdateCQLResult cqlResult, CQLArtifactHolder usedCQLArtifactHolder) {
+    private List<HumanReadableExpressionModel> getFunctions(XmlProcessor parentLibraryProcessor, Map<String, XmlProcessor> includedLibraryXmlProcessors, SaveUpdateCQLResult cqlResult, CQLArtifactHolder usedCQLArtifactHolder) {
         List<HumanReadableExpressionModel> functions = new ArrayList<>();
         List<String> usedFunctions = cqlResult.getUsedCQLArtifacts().getUsedCQLFunctions();
         List<String> functionsList = new ArrayList<>(usedCQLArtifactHolder.getCqlFuncFromPopSet());
@@ -363,31 +342,6 @@ public class HumanReadableGenerator {
             functions.add(expression);
         }
 
-        return functions;
-    }
-
-    private List<HumanReadableExpressionModel> getFunctionsFHIR(CQLModel cqlModel,
-                                                                XmlProcessor parentLibraryProcessor,
-                                                                Map<String, XmlProcessor> includedLibraryXmlProcessors) {
-        List<HumanReadableExpressionModel> functions = new ArrayList<>();
-        cqlModel.getCqlFunctions().stream().
-                sorted((d1, d2) -> String.CASE_INSENSITIVE_ORDER.compare(d1.getName(), d2.getName())).
-                forEach(f -> {
-                    String name = f.getName();
-                    String statementIdentifier = name;
-                    XmlProcessor currentProcessor = parentLibraryProcessor;
-                    String[] arr = name.split(Pattern.quote("|"));
-                    if (arr.length == 3) {
-                        name = arr[2];
-                        statementIdentifier = arr[1] + "." + arr[2];
-                        currentProcessor = includedLibraryXmlProcessors.get(arr[0] + "|" + arr[1]);
-                    }
-
-                    HumanReadableExpressionModel expression = new HumanReadableExpressionModel(
-                            statementIdentifier + getCQLFunctionSignature(name, currentProcessor),
-                            getLogicStringFromXMLByName(name, CQLFUNCTION, currentProcessor));
-                    functions.add(expression);
-                });
         return functions;
     }
 

--- a/src/main/java/mat/server/humanreadable/HumanReadableGenerator.java
+++ b/src/main/java/mat/server/humanreadable/HumanReadableGenerator.java
@@ -145,13 +145,10 @@ public class HumanReadableGenerator {
                 XMLMarshalUtil xmlMarshalUtil = new XMLMarshalUtil();
 
                 HumanReadableModel model = (HumanReadableModel) xmlMarshalUtil.convertXMLToObject("SimpleXMLHumanReadableModelMapping.xml", simpleXml, HumanReadableModel.class);
-                List<String> measureTypes = null;
                 if (model.getMeasureInformation() != null && CollectionUtils.isNotEmpty(model.getMeasureInformation().getMeasureTypes())) {
-                    measureTypes = new ArrayList<>(model.getMeasureInformation().getMeasureTypes());
-                    Collections.sort(measureTypes);
+                    Collections.sort(model.getMeasureInformation().getMeasureTypes());
                 }
 
-                model.getMeasureInformation().setMeasureTypes(measureTypes);
                 model.setPopulationCriterias(getPopulationCriteriaModels(processor));
                 model.setSupplementalDataElements(getSupplementalDataElements(processor));
                 model.setRiskAdjustmentVariables(getRiskAdjustmentVariables(processor));

--- a/src/main/java/mat/server/service/impl/SimpleEMeasureServiceImpl.java
+++ b/src/main/java/mat/server/service/impl/SimpleEMeasureServiceImpl.java
@@ -726,7 +726,6 @@ public class SimpleEMeasureServiceImpl implements SimpleEMeasureService {
         return humanReadableGenerator.generateHTMLForMeasure(measureId, simpleXmlStr, measureVersionNumber, cqlLibraryDAO, dataRequirementsNoValueSet);
     }
 
-
     public ExportResult getHQMF(String measureId) {
         MeasureExport measureExport = getMeasureExport(measureId);
 

--- a/src/main/java/mat/server/util/CQLUtil.java
+++ b/src/main/java/mat/server/util/CQLUtil.java
@@ -597,19 +597,10 @@ public class CQLUtil {
     private static void validateCQLWithIncludes(CQLModel cqlModel, Map<String, LibHolderObject> cqlLibNameMap,
                                                 SaveUpdateCQLResult result, List<String> exprList, boolean generateELM) {
 
-        Map<String, String> libraryMap = new HashMap<>();
-
         // get the strings for parsing
         String parentCQLString = CQLUtilityClass.getCqlString(cqlModel, "").getLeft();
         String parentLibraryName = cqlModel.getLibraryName() + "-" + cqlModel.getVersionUsed();
-        libraryMap.put(parentLibraryName, parentCQLString);
-        for (String cqlLibName : cqlLibNameMap.keySet()) {
-            CQLModel includedCQLModel = CQLUtilityClass.getCQLModelFromXML(cqlLibNameMap.get(cqlLibName).getMeasureXML());
-
-            LibHolderObject libHolderObject = cqlLibNameMap.get(cqlLibName);
-            String includedCQLString = CQLUtilityClass.getCqlString(includedCQLModel, "").getLeft();
-            libraryMap.put(libHolderObject.getCqlLibrary().getCqlLibraryName() + "-" + libHolderObject.getCqlLibrary().getVersion(), includedCQLString);
-        }
+        Map<String, String> libraryMap = buildLibraryMap(parentCQLString, parentLibraryName, cqlLibNameMap);
 
         // do the parsing
         CQLtoELM cqlToELM = new CQLtoELM(parentCQLString, libraryMap);
@@ -650,6 +641,20 @@ public class CQLUtil {
         result.setCqlWarnings(warnings);
         result.setLibraryNameErrorsMap(libraryNameErrorsMap);
         result.setLibraryNameWarningsMap(libraryNameWarningsMap);
+    }
+
+    private static Map<String, String> buildLibraryMap(String parentCQL, String parentLibraryName, Map<String, LibHolderObject> cqlLibNameMap) {
+        Map<String, String> libraryMap = new HashMap<>();
+        libraryMap.put(parentCQL, parentLibraryName);
+
+        for (String cqlLibName : cqlLibNameMap.keySet()) {
+            CQLModel includedCQLModel = CQLUtilityClass.getCQLModelFromXML(cqlLibNameMap.get(cqlLibName).getMeasureXML());
+
+            LibHolderObject libHolderObject = cqlLibNameMap.get(cqlLibName);
+            String includedCQLString = CQLUtilityClass.getCqlString(includedCQLModel, "").getLeft();
+            libraryMap.put(libHolderObject.getCqlLibrary().getCqlLibraryName() + "-" + libHolderObject.getCqlLibrary().getVersion(), includedCQLString);
+        }
+        return libraryMap;
     }
 
     private static void validateMeasurementPeriodReturnType(CQLtoELM cqlToELM, String libraryName, List<CQLError> errors, Map<String, List<CQLError>> libraryNameErrorsMap) {


### PR DESCRIPTION
## Description
When a define or function used in the call stack for a population (IPP, Denom, Num, etc) is from an external library (Global, FHIRHelpers, etc), include that define or function in the FHIR Human Readable.
    
Support for external defines/functions already exists for QDM HRs. This change brings the definition and function lists in the FHIR HR up to parity with QDM HR.
    
The current FHIR specific logic for generating the list of defines/functions used by the populations does not account for external libraries. Since the similar QDM logic does account for external libraries and is actually model agnostic, remove the FHIR specific logic and use the existing QDM logic in its place.
    
The call to the FHIR Microservices is still necessary to ensure validation is complete prior to assembling the Human Readable, however; non-exception results can now be safely ignored.

#### Add'l Changes
- Refactor define and function parsing methods
- Remove unnecessary temp List creation
- Minor refactoring and whitespace cleanup

## JIRA Ticket
[MAT-3226](https://jira.cms.gov/browse/MAT-3226)
<!--- Link to JIRA ticket -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
<!--- Put an `x` in the box when Screenshots are not relevant. Delete below line if adding screenshots. -->
- [ ] None applicable
