### PR TITLE
[MAT-3232] Strip query params from logout URL

### DIFF
--- a/src/main/java/mat/client/MainLayout.java
+++ b/src/main/java/mat/client/MainLayout.java
@@ -390,13 +390,10 @@ public abstract class MainLayout {
 
         Hidden redirect = new Hidden();
         redirect.setName("post_logout_redirect_uri");
-        String path = Window.Location.getPath();
-        String redirectUrl = Window.Location.createUrlBuilder()
-                .setPath(path.substring(0, path.lastIndexOf('/')) + ClientConstants.HTML_LOGIN)
-                .buildString();
-        if (redirectUrl.contains("#")) {
-            redirectUrl = redirectUrl.substring(0, redirectUrl.lastIndexOf('#'));
-        }
+        // logout redirect uri needs to be whitelisted in Okta App configuration,
+        // and the redirect request is ignored.
+        String currentUrl = Window.Location.getHref();
+        String redirectUrl = currentUrl.substring(0, currentUrl.lastIndexOf('/')) + ClientConstants.HTML_LOGIN;
         redirect.setValue(redirectUrl);
 
         panel.add(token);

--- a/src/main/java/mat/client/Mat.java
+++ b/src/main/java/mat/client/Mat.java
@@ -715,13 +715,13 @@ public class Mat extends MainLayout implements EntryPoint, Enableable, TabObserv
             public void onSuccess(String harpUrl) {
                 logger.log(Level.INFO, "HarpService::getHarpUrl -> onSuccess");
                 MatContext.get().getSynchronizationDelegate().setLogOffFlag();
-                harpLogout(harpUrl);
                 removeOktaTokens();
+                harpLogout(harpUrl);
                 if (redirectTo == null) {
                     // MAT logout operation, but don't redirect.
-                    MatContext.get().handleSignOut("SIGN_OUT_EVENT", redirectTo);
+                    MatContext.get().handleSignOut("SIGN_OUT_EVENT", null);
 
-                    // Redirect to Login after 1 second wait.
+                    // Redirect to Login.html after 1 second wait.
                     redirectToLogin();
                 }
                 // MAT Logout operation with specified redirect.

--- a/src/main/java/mat/client/Mat.java
+++ b/src/main/java/mat/client/Mat.java
@@ -708,7 +708,7 @@ public class Mat extends MainLayout implements EntryPoint, Enableable, TabObserv
         MatContext.get().getHarpService().getHarpUrl(new AsyncCallback<String>() {
             @Override
             public void onFailure(Throwable throwable) {
-                logger.log(Level.SEVERE, "HarpService::getHarpUrl -> onFailure " + throwable.getMessage(), throwable);
+                logger.log(Level.SEVERE, "HarpService::getHarpUrl -> onFailure");
             }
 
             @Override

--- a/src/main/java/mat/client/shared/MatContext.java
+++ b/src/main/java/mat/client/shared/MatContext.java
@@ -57,7 +57,6 @@ import mat.client.population.service.PopulationServiceAsync;
 import mat.client.umls.service.VSACAPIService;
 import mat.client.umls.service.VSACAPIServiceAsync;
 import mat.client.umls.service.VsacApiResult;
-import mat.client.util.FeatureFlagConstant;
 import mat.dto.CompositeMeasureScoreDTO;
 import mat.dto.OperatorDTO;
 import mat.dto.UserPreferenceDTO;
@@ -607,12 +606,9 @@ public class MatContext implements IsSerializable {
     }
 
     public void redirectToHtmlPage(String html) {
-        UrlBuilder urlBuilder = Window.Location.createUrlBuilder();
-        String path = Window.Location.getPath();
-        path = path.substring(0, path.lastIndexOf('/'));
-        path += html;
-        urlBuilder.setPath(path);
-        Window.Location.replace(urlBuilder.buildString());
+        String currentUrl = Window.Location.getHref();
+        String redirectUrl = currentUrl.substring(0, currentUrl.lastIndexOf('/')) + html;
+        Window.Location.replace(redirectUrl);
     }
 
     public void redirectToMatPage(String html) {
@@ -629,7 +625,6 @@ public class MatContext implements IsSerializable {
         Window.open(html, "User_Guide", "");
 
     }
-
 
     public void openNewHtmlPage(String html) {
         String windowFeatures = "toolbar=no, location=no, personalbar=no, menubar=yes, scrollbars=yes, resizable=yes";


### PR DESCRIPTION
<!--- In the *Title* field above, please provide the JIRA ticket number and a general summary of your changes -->
## Description
### Build the logout redirect URL from Href

The GWT `createUrlBuilder()` method functions more as a find and replace against the current URL than a new URL builder. This causes any parameters to remain in the built URL, causing issues when logging out from Okta  (where logout URLs must be whitelisted).

Using the Href as a base and stripping away the parameters seems to be the cleanest path to generating a consistent, though environment independent, URL without any parameters or unexpected pathing.

### Remove logging of Login page html on 403
When the frontend request results in a 403, GWT generates a `Throwable` containing the Login.html based on the Spring HttpSecurity configuration. Logging this info is overly verbose and not helpful in researching the issue.

### Remove tokens prior to calling Okta logout
The otka logout flow uses the id token stored in `MatContext`, so the tokens in Local Storage can be removed prior to the okta logout. This will help mitigate situations where the stored tokens permit a log in to the MAT unexpectedly.
<!--- Describe your changes in detail -->

## JIRA Ticket
[MAT-3232](https://jira.cms.gov/browse/MAT-3232)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
<!--- Put an `x` in the box when Screenshots are not relevant. Delete below line if adding screenshots. -->
- [ ] None applicable
