### PR TITLE
Check for Code System OID prefix before appending said prefix

### DIFF
--- a/src/main/java/mat/server/CQLUtilityClass.java
+++ b/src/main/java/mat/server/CQLUtilityClass.java
@@ -491,7 +491,12 @@ public final class CQLUtilityClass {
 
                         if (!codeSystemAlreadyUsed.contains(codeSysStr)) {
                             sb.append("codesystem \"").append(codeSysStr).append('"').append(": ");
-                            sb.append("'urn:oid:").append(code.getCodeSystemOID()).append("' ");
+                            if(code.getCodeSystemOID().startsWith("urn:oid:")) {
+                                sb.append('\'');
+                            } else {
+                                sb.append("'urn:oid:");
+                            }
+                            sb.append(code.getCodeSystemOID()).append("' ");
                             sb.append(codeSysVersion);
                             sb.append("\n");
 


### PR DESCRIPTION
## Description
The CDCREC Code System's FHIR URL is an OID with the `urn:oid` prefix, the first OID based FHIR URL accepted by the MAT. As a result, it is triggering older QDM code that expects the code system OID to come from VSAC without the prefix and adds it to the CQL `codesystem` statement.

The FHIR URL comes from the code system mapping json, instead of VSAC, and the mapping entry is also used for validation, requiring the code system url in the CQL match the mapping entry exactly. Hence, the prefix must be present in the mapping entry.

This will check if the prefix is already present before adding it to the `codesystem` statement.
<!--- Describe your changes in detail -->

## JIRA Ticket
[MAT-3277](https://jira.cms.gov/browse/MAT-3277)<!--- Link to JIRA ticket -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
<!--- Put an `x` in the box when Screenshots are not relevant. Delete below line if adding screenshots. -->
- [x] None applicable
