### PR TITLE
Increase inactivity warning threshold to 25 minutes

### DIFF
--- a/src/main/java/mat/client/shared/TimeoutManager.java
+++ b/src/main/java/mat/client/shared/TimeoutManager.java
@@ -25,7 +25,7 @@ import java.util.Date;
 class TimeoutManager {
 
 	/** The Constant WARNING_TIME. */
-	private static final int WARNING_TIME = 10 * 60 * 1000;
+	private static final int WARNING_TIME = 25 * 60 * 1000;
 
 	/** The Constant WARNING_INTERVAL. */
 	private static final int WARNING_INTERVAL = 5 * 60 * 1000;


### PR DESCRIPTION
## Description
Increasing the time threshold before displaying an inactivity warning to users to 25 minutes, up from 10 minutes.

Combined with the post-warning threshold of 5 minutes, this change will increase the overall timeout threshold to 30 minutes.
<!--- Describe your changes in detail -->

## JIRA Ticket
[MAT-2880](https://jira.cms.gov/browse/MAT-2880)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [x] Tests have been run locally and pass.

## Screenshots (if appropriate)
<!--- Put an `x` in the box when Screenshots are not relevant. Delete below line if adding screenshots. -->
- [x] None applicable
