### PR TITLE
Re-add Measure Scoring type check around MO display in HR

### DIFF
--- a/src/main/resources/templates/humanreadable/measure_information_table.ftl
+++ b/src/main/resources/templates/humanreadable/measure_information_table.ftl
@@ -271,6 +271,7 @@
                 </td>
             </tr>
         </#if>
+        <#if model.measureInformation.measureScoring?lower_case == "continuous variable" || model.measureInformation.measureScoring?lower_case == "ratio">
             <tr>
                 <th scope="row" class="row-header"><span class="td_label">Measure Observations</span></th>
                 <td style="width:80%" colspan="3">
@@ -279,6 +280,7 @@
                     </div>
                 </td>
             </tr>
+        </#if>
         <#if model.measureInformation.measureScoring?lower_case == "proportion" || model.measureInformation.measureScoring?lower_case == "ratio">
             <tr>
                 <th scope="row" class="row-header"><span class="td_label">Numerator</span></th>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The measure score type check around Measure Observation display in the Human Readable was accidentally removed during an update to enable patient-based ratio measures.

Measure Observation metadata should only be displayed in the HR for CV and Ratio measures.

## JIRA Ticket
<!--- Link to JIRA ticket -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
<!--- Put an `x` in the box when Screenshots are not relevant. Delete below line if adding screenshots. -->
- [ ] None applicable
