### PR TITLE
[MAT-5708] Upgrade cqframework to 2.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
             <artifactId>commons-io</artifactId>
             <version>2.11.0</version>
         </dependency>
+
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>cql</artifactId>
@@ -125,21 +126,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.13.2.2</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>quick</artifactId>
             <version>${cqframework.version}</version>
@@ -153,6 +139,27 @@
             <groupId>info.cqframework</groupId>
             <artifactId>cql-formatter</artifactId>
             <version>${cqframework.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.cqframework</groupId>
+            <artifactId>model-jackson</artifactId>
+            <version>${cqframework.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.4.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <jacoco.version>0.8.6</jacoco.version>
         <jaxb.version>2.3.0</jaxb.version>
         <hapi-fhir-version>4.1.0</hapi-fhir-version>
-        <jackson.version>2.13.2</jackson.version>
+        <jackson.version>2.13.4</jackson.version>
 
         <gwt.sourceLevel>1.8</gwt.sourceLevel>
         <java.version>11</java.version>
@@ -125,6 +125,15 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- See https://github.com/cqframework/clinical_quality_language/blob/master/Src/java/cql-to-elm/build.gradle -->
+        <!--  Users of the CQL translator will need to supply their own implementation or add xpp3 at runtime. -->
+        <dependency>
+            <groupId>org.ogce</groupId>
+            <artifactId>xpp3</artifactId>
+            <version>1.1.6</version>
+        </dependency>
+
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>quick</artifactId>
@@ -140,6 +149,19 @@
             <artifactId>cql-formatter</artifactId>
             <version>${cqframework.version}</version>
         </dependency>
+
+        <!-- Resolves: No ElmLibraryWriterProviders found on the classpath.
+                You need to add a reference to one of the 'elm-jackson' or 'elm-jaxb' packages,
+                or provide your own implementation.-->
+        <dependency>
+            <groupId>info.cqframework</groupId>
+            <artifactId>elm-jackson</artifactId>
+            <version>${cqframework.version}</version>
+        </dependency>
+
+        <!-- Resolves: No ModelInfoReaderProviders found on the classpath.
+                You need to add a reference to one of the 'model-jackson' or 'model-jaxb' packages,
+                or provide your own implementation.-->
         <dependency>
             <groupId>info.cqframework</groupId>
             <artifactId>model-jackson</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <gwtbootstrap3.extra.version>1.0.2</gwtbootstrap3.extra.version>
         <elemental.version>1.1.0</elemental.version>
         <gwt.elemento.version>0.9.6-gwt2</gwt.elemento.version>
-        <cqframework.version>1.5.3</cqframework.version>
+        <cqframework.version>2.9.0</cqframework.version>
         <axis.version>1.8.0</axis.version>
         <castor.version>1.4.1</castor.version>
         <slf4j.version>1.7.30</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <gwtbootstrap3.extra.version>1.0.2</gwtbootstrap3.extra.version>
         <elemental.version>1.1.0</elemental.version>
         <gwt.elemento.version>0.9.6-gwt2</gwt.elemento.version>
-        <cqframework.version>2.9.0</cqframework.version>
+        <cqframework.version>2.10.0</cqframework.version>
         <axis.version>1.8.0</axis.version>
         <castor.version>1.4.1</castor.version>
         <slf4j.version>1.7.30</slf4j.version>

--- a/src/main/java/cqltoelm/CQLtoELM.java
+++ b/src/main/java/cqltoelm/CQLtoELM.java
@@ -334,7 +334,7 @@ public class CQLtoELM {
                 try {
                     this.elmStrings.add(CqlTranslator.convertToXml(library.getLibrary()));
                 } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    e.printStackTrace();
                 }
             }
         }
@@ -346,7 +346,7 @@ public class CQLtoELM {
                 try {
                     this.jsonStrings.add(CqlTranslator.convertToJson(library.getLibrary()));
                 } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    e.printStackTrace();
                 }
             }
         }

--- a/src/main/java/cqltoelm/CQLtoELM.java
+++ b/src/main/java/cqltoelm/CQLtoELM.java
@@ -6,13 +6,13 @@ import cqltoelm.parsers.TrackbackListener;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.cqframework.cql.cql2elm.CqlCompilerException;
 import org.cqframework.cql.cql2elm.CqlTranslator;
-import org.cqframework.cql.cql2elm.CqlTranslatorException;
 import org.cqframework.cql.cql2elm.CqlTranslatorOptions;
 import org.cqframework.cql.cql2elm.DefaultLibrarySourceProvider;
 import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.cql2elm.ModelManager;
-import org.cqframework.cql.cql2elm.model.TranslatedLibrary;
+import org.cqframework.cql.cql2elm.model.CompiledLibrary;
 import org.cqframework.cql.elm.tracking.TrackBack;
 import org.cqframework.cql.gen.cqlLexer;
 import org.cqframework.cql.gen.cqlParser;
@@ -26,7 +26,6 @@ import org.hl7.elm.r1.Library;
 import org.hl7.elm.r1.ParameterDef;
 import org.hl7.elm.r1.VersionedIdentifier;
 
-import javax.xml.bind.JAXBException;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -95,17 +94,17 @@ public class CQLtoELM {
     /**
      * The messagse from cql-to-elm translation
      */
-    private List<CqlTranslatorException> messages = new ArrayList<>();
+    private List<CqlCompilerException> messages = new ArrayList<>();
 
     /**
      * The warnings from cql-to-elm translation
      */
-    private List<CqlTranslatorException> warnings = new ArrayList<>();
+    private List<CqlCompilerException> warnings = new ArrayList<>();
 
     /**
      * The errors from cql-to-elm translation
      */
-    private List<CqlTranslatorException> errors = new ArrayList<>();
+    private List<CqlCompilerException> errors = new ArrayList<>();
 
     private Map<String, TrackBack> trackBackMap = new HashMap<>();
 
@@ -113,7 +112,7 @@ public class CQLtoELM {
 
     private LibraryManager libraryManager;
 
-    private Map<String, TranslatedLibrary> translatedLibraries = new HashMap<>();
+    private Map<String, CompiledLibrary> translatedLibraries = new HashMap<>();
 
 
     /**
@@ -172,7 +171,7 @@ public class CQLtoELM {
         formats.add("JSON");
         doTranslation(false, true, true, false, false, false,
                 true, true, false, false,
-                true, true, CqlTranslatorException.ErrorSeverity.Error, validationOnly, formats);
+                true, true, CqlCompilerException.ErrorSeverity.Error, validationOnly, formats);
     }
 
     /**
@@ -187,7 +186,7 @@ public class CQLtoELM {
         formats.add(format);
         doTranslation(false, true, true, false, false, false,
                 true, true, false, false,
-                true, true, CqlTranslatorException.ErrorSeverity.Error, validationOnly, formats);
+                true, true, CqlCompilerException.ErrorSeverity.Error, validationOnly, formats);
     }
 
     /**
@@ -214,52 +213,52 @@ public class CQLtoELM {
                               boolean enableResultTypes, boolean enableDetailedErrors, boolean disableListTraversal,
                               boolean disableListDemotion, boolean disableListPromotion, boolean enableIntervalDemotion, boolean enableIntervalPromotion,
                               boolean disableMethodInvocation, boolean validateUnits,
-                              CqlTranslatorException.ErrorSeverity errorSeverity, boolean validationOnly, List<String> formats) {
+                              CqlCompilerException.ErrorSeverity errorSeverity, boolean validationOnly, List<String> formats) {
 
         // add in all of the flags
-        List<CqlTranslator.Options> options = new ArrayList<>();
+        List<CqlTranslatorOptions.Options> options = new ArrayList<>();
         if (enableDateRangeOptimization) {
-            options.add(CqlTranslator.Options.EnableDateRangeOptimization);
+            options.add(CqlTranslatorOptions.Options.EnableDateRangeOptimization);
         }
 
         if (enableAnnotations) {
-            options.add(CqlTranslator.Options.EnableAnnotations);
+            options.add(CqlTranslatorOptions.Options.EnableAnnotations);
         }
 
         if (enableLocators) {
-            options.add(CqlTranslator.Options.EnableLocators);
+            options.add(CqlTranslatorOptions.Options.EnableLocators);
         }
 
         if (enableResultTypes) {
-            options.add(CqlTranslator.Options.EnableResultTypes);
+            options.add(CqlTranslatorOptions.Options.EnableResultTypes);
         }
 
         if (enableDetailedErrors) {
-            options.add(CqlTranslator.Options.EnableDetailedErrors);
+            options.add(CqlTranslatorOptions.Options.EnableDetailedErrors);
         }
 
         if (disableListTraversal) {
-            options.add(CqlTranslator.Options.DisableListTraversal);
+            options.add(CqlTranslatorOptions.Options.DisableListTraversal);
         }
 
         if (disableListDemotion) {
-            options.add(CqlTranslator.Options.DisableListDemotion);
+            options.add(CqlTranslatorOptions.Options.DisableListDemotion);
         }
 
         if (disableListPromotion) {
-            options.add(CqlTranslator.Options.DisableListPromotion);
+            options.add(CqlTranslatorOptions.Options.DisableListPromotion);
         }
 
         if (enableIntervalDemotion) {
-            options.add(CqlTranslator.Options.EnableIntervalDemotion);
+            options.add(CqlTranslatorOptions.Options.EnableIntervalDemotion);
         }
 
         if (enableIntervalPromotion) {
-            options.add(CqlTranslator.Options.EnableIntervalPromotion);
+            options.add(CqlTranslatorOptions.Options.EnableIntervalPromotion);
         }
 
         if (disableMethodInvocation) {
-            options.add(CqlTranslator.Options.DisableMethodInvocation);
+            options.add(CqlTranslatorOptions.Options.DisableMethodInvocation);
         }
 
         // parse from string
@@ -279,14 +278,14 @@ public class CQLtoELM {
         if (parentCQLLibraryString != null && parentCQLLibraryFile == null) {
             libraryManager.getLibrarySourceLoader().registerProvider(
                     new StringLibrarySourceProvider(this.cqlLibraryMapping));
-            writeToELM(options.toArray(new CqlTranslator.Options[options.size()]), errorSeverity, formats, modelManager, libraryManager, ucumService);
+            writeToELM(options.toArray(new CqlTranslatorOptions.Options[options.size()]), errorSeverity, formats, modelManager, libraryManager, ucumService);
         }
 
         // parse from file
         else {
             libraryManager.getLibrarySourceLoader().registerProvider(
                     new DefaultLibrarySourceProvider(this.parentCQLLibraryFile.getParentFile().toPath()));
-            writeToELM(options.toArray(new CqlTranslator.Options[options.size()]), errorSeverity, formats, modelManager, libraryManager, ucumService);
+            writeToELM(options.toArray(new CqlTranslatorOptions.Options[options.size()]), errorSeverity, formats, modelManager, libraryManager, ucumService);
         }
 
     }
@@ -296,7 +295,7 @@ public class CQLtoELM {
      *
      * @param options the parser options
      */
-    private void writeToELM(CqlTranslator.Options[] options, CqlTranslatorException.ErrorSeverity errorSeverity, List<String> formats, ModelManager modelManager,
+    private void writeToELM(CqlTranslatorOptions.Options[] options, CqlCompilerException.ErrorSeverity errorSeverity, List<String> formats, ModelManager modelManager,
                             LibraryManager libraryManager, UcumService ucumService) {
 
         CqlTranslator translator = null;
@@ -331,11 +330,11 @@ public class CQLtoELM {
         // output the elm strings
         if (formats.contains("XML")) {
             this.parentElmString = translator.toXml();
-            for (TranslatedLibrary library : translatedLibraries.values()) {
+            for (CompiledLibrary library : translatedLibraries.values()) {
                 try {
-                    this.elmStrings.add(translator.convertToXml(library.getLibrary()));
-                } catch (JAXBException e) {
-                    e.printStackTrace();
+                    this.elmStrings.add(CqlTranslator.convertToXml(library.getLibrary()));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
                 }
             }
         }
@@ -343,17 +342,17 @@ public class CQLtoELM {
         // output the json strings
         if (formats.contains("JSON")) {
             this.parentJsonString = translator.toJson();
-            for (TranslatedLibrary library : translatedLibraries.values()) {
+            for (CompiledLibrary library : translatedLibraries.values()) {
                 try {
-                    this.jsonStrings.add(translator.convertToJson(library.getLibrary()));
-                } catch (JAXBException e) {
-                    e.printStackTrace();
+                    this.jsonStrings.add(CqlTranslator.convertToJson(library.getLibrary()));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
                 }
             }
         }
     }
 
-    private void fetchTranslatedLibraries(TranslatedLibrary parentLibrary) throws CqlTranslatorException {
+    private void fetchTranslatedLibraries(CompiledLibrary parentLibrary) throws CqlCompilerException {
         this.translatedLibraries.put(parentLibrary.getIdentifier().getId() + "-" + parentLibrary.getIdentifier().getVersion(), parentLibrary);
 
         if (parentLibrary.getLibrary().getIncludes() != null) {
@@ -362,7 +361,7 @@ public class CQLtoELM {
                 identifier.setId(include.getPath());
                 identifier.setVersion(include.getVersion());
                 try {
-                    TranslatedLibrary childLibrary = libraryManager.resolveLibrary(identifier,
+                    CompiledLibrary childLibrary = libraryManager.resolveLibrary(identifier,
                             new CqlTranslatorOptions(),
                             new ArrayList<>());
                     fetchTranslatedLibraries(childLibrary);
@@ -428,7 +427,7 @@ public class CQLtoELM {
      *
      * @return the messages
      */
-    public List<CqlTranslatorException> getMessages() {
+    public List<CqlCompilerException> getMessages() {
         return messages;
     }
 
@@ -437,7 +436,7 @@ public class CQLtoELM {
      *
      * @return the warnings
      */
-    public List<CqlTranslatorException> getWarnings() {
+    public List<CqlCompilerException> getWarnings() {
         return warnings;
     }
 
@@ -446,7 +445,7 @@ public class CQLtoELM {
      *
      * @return the errors
      */
-    public List<CqlTranslatorException> getErrors() {
+    public List<CqlCompilerException> getErrors() {
         return errors;
     }
 
@@ -560,7 +559,7 @@ public class CQLtoELM {
         return this.translator;
     }
 
-    public Map<String, TranslatedLibrary> getTranslatedLibraries() {
+    public Map<String, CompiledLibrary> getTranslatedLibraries() {
         return this.translatedLibraries;
     }
 
@@ -585,7 +584,7 @@ public class CQLtoELM {
 
         Map<String, List<CQLExpressionError>> expressionErrorMap = new HashMap<>();
 
-        List<CqlTranslatorException> errors = this.getErrors();
+        List<CqlCompilerException> errors = this.getErrors();
 
         // if there are no errors, nothing can be done.
         if (errors == null) {
@@ -603,7 +602,7 @@ public class CQLtoELM {
                 int expressionEndLine = currentTrackBack.getEndLine();
 
                 List<CQLExpressionError> expressionErrors = new ArrayList<>();
-                for (CqlTranslatorException error : errors) {
+                for (CqlCompilerException error : errors) {
 
                     int errorStartLine = error.getLocator().getStartLine();
                     int errorEndLine = error.getLocator().getEndLine();
@@ -614,7 +613,7 @@ public class CQLtoELM {
                         int endLine = startLine + difference;
                         int startChar = error.getLocator().getStartChar();
                         int endChar = error.getLocator().getEndChar();
-                        CqlTranslatorException.ErrorSeverity severity = error.getSeverity();
+                        CqlCompilerException.ErrorSeverity severity = error.getSeverity();
 
                         CQLExpressionError cqlExpressionError = new CQLExpressionError(error.getMessage(), startLine,
                                 endLine, startChar, endChar, severity);
@@ -660,8 +659,8 @@ public class CQLtoELM {
         }
     }
 
-    private static void outputExceptions(Iterable<CqlTranslatorException> exceptions) {
-        for (CqlTranslatorException error : exceptions) {
+    private static void outputExceptions(Iterable<CqlCompilerException> exceptions) {
+        for (CqlCompilerException error : exceptions) {
             TrackBack tb = error.getLocator();
             String lines = tb == null ? "[n/a]" : String.format("[%d:%d, %d:%d]",
                     tb.getStartLine(), tb.getStartChar(), tb.getEndLine(), tb.getEndChar());

--- a/src/main/java/cqltoelm/MATCQLFilter.java
+++ b/src/main/java/cqltoelm/MATCQLFilter.java
@@ -7,7 +7,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 import org.cqframework.cql.cql2elm.CqlTranslator;
-import org.cqframework.cql.cql2elm.model.TranslatedLibrary;
+import org.cqframework.cql.cql2elm.model.CompiledLibrary;
 import org.cqframework.cql.cql2elm.preprocessor.CqlPreprocessorVisitor;
 import org.cqframework.cql.gen.cqlLexer;
 import org.cqframework.cql.gen.cqlParser;
@@ -17,11 +17,9 @@ import org.hl7.elm.r1.Library;
 import org.hl7.elm.r1.ParameterDef;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -33,7 +31,7 @@ public class MATCQLFilter {
 
     private String parentLibraryString;
     private Map<String, String> childrenLibraries;
-    private TranslatedLibrary library;
+    private CompiledLibrary library;
     private CqlTranslator translator;
 
     /**
@@ -70,7 +68,7 @@ public class MATCQLFilter {
 
     private Map<String, String> qdmTypeInfoMap = new HashMap<>();
 
-    private Map<String, TranslatedLibrary> translatedLibraryMap;
+    private Map<String, CompiledLibrary> translatedLibraryMap;
 
     /**
      * Map in the form of <LibraryName-x.x.xxx, <ExpressionName, ReturnType>>.
@@ -94,7 +92,7 @@ public class MATCQLFilter {
             Map<String, String> childrenLibraries,
             List<String> parentExpressions,
             CqlTranslator translator,
-            Map<String, TranslatedLibrary> translatedLibraries) {
+            Map<String, CompiledLibrary> translatedLibraries) {
 
         this.parentLibraryString = parentLibraryString;
         this.translator = translator;
@@ -316,7 +314,7 @@ public class MATCQLFilter {
 
         if (null != this.library.getLibrary().getIncludes()) {
             for (IncludeDef include : this.library.getLibrary().getIncludes().getDef()) {
-                TranslatedLibrary lib = this.translatedLibraryMap.get(include.getPath() + "-" + include.getVersion());
+                CompiledLibrary lib = this.translatedLibraryMap.get(include.getPath() + "-" + include.getVersion());
 
                 Library.Statements statementsFromIncludedLibrary = lib.getLibrary().getStatements();
                 Library.Parameters parametersFromIncludedLibrary = lib.getLibrary().getParameters();

--- a/src/main/java/cqltoelm/models/CQLExpressionError.java
+++ b/src/main/java/cqltoelm/models/CQLExpressionError.java
@@ -1,6 +1,6 @@
 package cqltoelm.models;
 
-import org.cqframework.cql.cql2elm.CqlTranslatorException;
+import org.cqframework.cql.cql2elm.CqlCompilerException;
 
 /**
  * @author Jack Meyer
@@ -34,9 +34,9 @@ public class CQLExpressionError {
      */
     private int endChar;
 
-    private CqlTranslatorException.ErrorSeverity severity;
+    private CqlCompilerException.ErrorSeverity severity;
 
-    public CQLExpressionError(String message, int startLine, int endLine, int startChar, int endChar, CqlTranslatorException.ErrorSeverity severity) {
+    public CQLExpressionError(String message, int startLine, int endLine, int startChar, int endChar, CqlCompilerException.ErrorSeverity severity) {
         this.message = message;
         this.startLine = startLine;
         this.endLine = endLine;
@@ -85,11 +85,11 @@ public class CQLExpressionError {
         this.endChar = endChar;
     }
 
-    public CqlTranslatorException.ErrorSeverity getSeverity() {
+    public CqlCompilerException.ErrorSeverity getSeverity() {
         return severity;
     }
 
-    public void setSeverity(CqlTranslatorException.ErrorSeverity severity) {
+    public void setSeverity(CqlCompilerException.ErrorSeverity severity) {
         this.severity = severity;
     }
 

--- a/src/main/java/cqltoelm/parsers/MATCQL2ELMListener.java
+++ b/src/main/java/cqltoelm/parsers/MATCQL2ELMListener.java
@@ -6,8 +6,8 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.misc.NotNull;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
-import org.apache.commons.collections.CollectionUtils;
-import org.cqframework.cql.cql2elm.model.TranslatedLibrary;
+import org.apache.commons.collections4.CollectionUtils;
+import org.cqframework.cql.cql2elm.model.CompiledLibrary;
 import org.cqframework.cql.cql2elm.preprocessor.CqlPreprocessorVisitor;
 import org.cqframework.cql.gen.cqlBaseListener;
 import org.cqframework.cql.gen.cqlLexer;
@@ -61,12 +61,12 @@ public class MATCQL2ELMListener extends cqlBaseListener {
     /**
      * The current library object from the parser
      */
-    private TranslatedLibrary library;
+    private CompiledLibrary library;
 
     /**
      * The map of the other libraries in the current library
      */
-    Map<String, TranslatedLibrary> translatedLibraryMap;
+    Map<String, CompiledLibrary> translatedLibraryMap;
 
     /**
      * The current context, aka which expression are we currently in.
@@ -88,7 +88,7 @@ public class MATCQL2ELMListener extends cqlBaseListener {
 
     private CQLGraph graph;
 
-    public MATCQL2ELMListener(CQLGraph graph, TranslatedLibrary library, Map<String, TranslatedLibrary> translatedLibraryMap,
+    public MATCQL2ELMListener(CQLGraph graph, CompiledLibrary library, Map<String, CompiledLibrary> translatedLibraryMap,
                               Map<String, String> childrenLibraries) {
         this.graph = graph;
         this.library = library;
@@ -98,8 +98,8 @@ public class MATCQL2ELMListener extends cqlBaseListener {
     }
 
     public MATCQL2ELMListener(String libraryIdentifier, CQLGraph graph,
-                              TranslatedLibrary library,
-                              Map<String, TranslatedLibrary> translatedLibraryMap,
+                              CompiledLibrary library,
+                              Map<String, CompiledLibrary> translatedLibraryMap,
                               Map<String, String> childrenLibraries) {
         this.graph = graph;
         this.library = library;
@@ -108,7 +108,7 @@ public class MATCQL2ELMListener extends cqlBaseListener {
         this.childrenLibraries = childrenLibraries;
     }
 
-    private TranslatedLibrary getCurrentLibraryContext() {
+    private CompiledLibrary getCurrentLibraryContext() {
         if (libraryAccessor != null) {
             return this.translatedLibraryMap.get(libraryAccessor.getPath() + "-" + libraryAccessor.getVersion());
         }
@@ -407,7 +407,7 @@ public class MATCQL2ELMListener extends cqlBaseListener {
         return formattedIdentifier;
     }
 
-    private Element resolve(String identifier, TranslatedLibrary library) {
+    private Element resolve(String identifier, CompiledLibrary library) {
         Element element = library.resolve(identifier);
         String formattedIdentifier = formatIdentifier(identifier);
         libraryAccessor = null; // we've done all we need to do with the accessor, so set it equal to null so it can be
@@ -460,7 +460,7 @@ public class MATCQL2ELMListener extends cqlBaseListener {
         CommonTokenStream tokens = new CommonTokenStream(lexer);
         cqlParser parser = new cqlParser(tokens);
 
-        TranslatedLibrary childLibrary = this.translatedLibraryMap.get(def.getPath() + "-" + def.getVersion());
+        CompiledLibrary childLibrary = this.translatedLibraryMap.get(def.getPath() + "-" + def.getVersion());
         cqltoelm.parsers.MATCQL2ELMListener listener = new cqltoelm.parsers.MATCQL2ELMListener(def.getPath() + "-" + def.getVersion() + "|" + def.getLocalIdentifier() + "|", graph, childLibrary, translatedLibraryMap, childrenLibraries);
         ParseTree tree = parser.library();
         CqlPreprocessorVisitor preprocessor = new CqlPreprocessorVisitor();

--- a/src/main/java/mat/dao/clause/impl/QDSAttributesDAOImpl.java
+++ b/src/main/java/mat/dao/clause/impl/QDSAttributesDAOImpl.java
@@ -6,7 +6,7 @@ import mat.dao.clause.QDSAttributesDAO;
 import mat.dao.search.GenericDAO;
 import mat.model.DataType;
 import mat.model.clause.QDSAttributes;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/mat/dao/impl/DataTypeDAOImpl.java
+++ b/src/main/java/mat/dao/impl/DataTypeDAOImpl.java
@@ -4,7 +4,7 @@ import mat.dao.DataTypeDAO;
 import mat.dao.search.GenericDAO;
 import mat.dto.DataTypeDTO;
 import mat.model.DataType;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/mat/dao/impl/FeatureFlagDAOImpl.java
+++ b/src/main/java/mat/dao/impl/FeatureFlagDAOImpl.java
@@ -4,7 +4,7 @@ import mat.dao.FeatureFlagDAO;
 import mat.dao.search.GenericDAO;
 import mat.model.FeatureFlag;
 import org.slf4j.LoggerFactory;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.hibernate.SessionFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/mat/dao/impl/ListObjectDAOImpl.java
+++ b/src/main/java/mat/dao/impl/ListObjectDAOImpl.java
@@ -2,7 +2,7 @@ package mat.dao.impl;
 
 import mat.dao.search.GenericDAO;
 import mat.model.ListObject;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/mat/dao/impl/OrganizationDAOImpl.java
+++ b/src/main/java/mat/dao/impl/OrganizationDAOImpl.java
@@ -3,7 +3,7 @@ package mat.dao.impl;
 import mat.dao.search.GenericDAO;
 import mat.model.Organization;
 import mat.model.User;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;

--- a/src/main/java/mat/server/CQLConstantServiceImpl.java
+++ b/src/main/java/mat/server/CQLConstantServiceImpl.java
@@ -13,6 +13,8 @@ import mat.dao.clause.QDSAttributesDAO;
 import mat.dto.DataTypeDTO;
 import mat.dto.UnitDTO;
 import mat.model.cql.CQLKeywords;
+import org.hl7.cql.model.ModelIdentifier;
+import org.hl7.cql.model.SystemModelInfoProvider;
 import org.slf4j.LoggerFactory;
 import mat.server.service.CodeListService;
 import mat.server.service.MeasureLibraryService;
@@ -22,8 +24,6 @@ import mat.server.util.QDMUtil;
 import mat.shared.cql.model.FunctionSignature;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
-import org.cqframework.cql.cql2elm.SystemModelInfoProvider;
-import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.elm_modelinfo.r1.ClassInfo;
 import org.hl7.elm_modelinfo.r1.ClassInfoElement;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
@@ -215,10 +215,10 @@ public class CQLConstantServiceImpl extends SpringRemoteServiceServlet implement
         CQLTypeContainer cqlTypeContainer = new CQLTypeContainer();
         SystemModelInfoProvider systemModelInfoProvider = new SystemModelInfoProvider();
 
-        VersionedIdentifier versionedIdentifier = new VersionedIdentifier();
-        versionedIdentifier.setId("System");
+        ModelIdentifier modelIdentifier = new ModelIdentifier();
+        modelIdentifier.setId("System");
 
-        ModelInfo modelInfo = systemModelInfoProvider.load(versionedIdentifier);
+        ModelInfo modelInfo = systemModelInfoProvider.load(modelIdentifier);
         Map<String, List<String>> typeToTypeAttributeMap = new HashMap<>();
 
         buildTypeToTypeAttributeMap(modelInfo, typeToTypeAttributeMap);

--- a/src/main/java/mat/server/MeasureLibraryServiceImpl.java
+++ b/src/main/java/mat/server/MeasureLibraryServiceImpl.java
@@ -116,7 +116,7 @@ import mat.shared.error.measure.DeleteMeasureException;
 import mat.shared.validator.measure.ManageCompositeMeasureModelValidator;
 import mat.shared.validator.measure.ManageMeasureModelValidator;
 import mat.vsacmodel.ValueSet;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;

--- a/src/main/java/mat/server/cqlparser/QdmCQLLinter.java
+++ b/src/main/java/mat/server/cqlparser/QdmCQLLinter.java
@@ -9,7 +9,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.cqframework.cql.gen.cqlLexer;
 import org.cqframework.cql.gen.cqlParser;

--- a/src/main/java/mat/server/humanreadable/HumanReadableGenerator.java
+++ b/src/main/java/mat/server/humanreadable/HumanReadableGenerator.java
@@ -28,7 +28,7 @@ import mat.server.util.XmlProcessor;
 import mat.shared.LibHolderObject;
 import mat.shared.MatConstants;
 import mat.shared.SaveUpdateCQLResult;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.exolab.castor.mapping.MappingException;
 import org.exolab.castor.xml.MarshalException;

--- a/src/main/java/mat/server/humanreadable/cql/HumanReadableMeasureInformationModel.java
+++ b/src/main/java/mat/server/humanreadable/cql/HumanReadableMeasureInformationModel.java
@@ -3,7 +3,7 @@ package mat.server.humanreadable.cql;
 import mat.client.measure.ManageCompositeMeasureDetailModel;
 import mat.client.measure.ManageMeasureDetailModel;
 import mat.client.measure.ReferenceTextAndType;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;

--- a/src/main/java/mat/server/humanreadable/helper/DataRequirementsNoValueSetFilter.java
+++ b/src/main/java/mat/server/humanreadable/helper/DataRequirementsNoValueSetFilter.java
@@ -3,7 +3,6 @@ package mat.server.humanreadable.helper;
 import mat.server.humanreadable.cql.HumanReadableTerminologyModel;
 import mat.server.humanreadable.cql.HumanReadableValuesetModel;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/mat/server/humanreadable/helper/DataRequirementsNoValueSetFilter.java
+++ b/src/main/java/mat/server/humanreadable/helper/DataRequirementsNoValueSetFilter.java
@@ -2,7 +2,7 @@ package mat.server.humanreadable.helper;
 
 import mat.server.humanreadable.cql.HumanReadableTerminologyModel;
 import mat.server.humanreadable.cql.HumanReadableValuesetModel;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;

--- a/src/main/java/mat/server/util/CQLUtil.java
+++ b/src/main/java/mat/server/util/CQLUtil.java
@@ -15,6 +15,7 @@ import mat.server.cqlparser.CQLLinter;
 import mat.server.cqlparser.CQLLinterConfig;
 import mat.server.cqlparser.FhirCQLLinter;
 import mat.server.cqlparser.QdmCQLLinter;
+import org.cqframework.cql.cql2elm.CqlCompilerException;
 import org.slf4j.LoggerFactory;
 import mat.shared.CQLError;
 import mat.shared.CQLExpressionObject;
@@ -26,7 +27,6 @@ import mat.shared.LibHolderObject;
 import mat.shared.SaveUpdateCQLResult;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
-import org.cqframework.cql.cql2elm.CqlTranslatorException;
 import org.cqframework.cql.elm.tracking.TrackBack;
 import org.hl7.elm.r1.FunctionDef;
 import org.hl7.elm.r1.OperandDef;
@@ -626,12 +626,12 @@ public class CQLUtil {
             validateMeasurementPeriodReturnType(cqlToELM, parentLibraryName, errors, libraryNameErrorsMap);
         }
 
-        for (CqlTranslatorException cte : cqlToELM.getErrors()) {
+        for (CqlCompilerException cte : cqlToELM.getErrors()) {
             setCQLErrors(parentLibraryName, errors, libraryNameErrorsMap, cte);
         }
 
         List<CQLError> warnings = new ArrayList<>();
-        for (CqlTranslatorException cte : cqlToELM.getWarnings()) {
+        for (CqlCompilerException cte : cqlToELM.getWarnings()) {
             setCQLErrors(parentLibraryName, warnings, libraryNameWarningsMap, cte);
         }
 
@@ -667,14 +667,14 @@ public class CQLUtil {
                 error.setEndErrorInLine(trackback.getEndLine());
                 error.setEndErrorAtOffset(trackback.getEndChar());
                 error.setErrorMessage("A Parameter titled \"Measurement Period\" must return an Interval<DateTime>");
-                error.setSeverity(CqlTranslatorException.ErrorSeverity.Error.toString());
+                error.setSeverity(CqlCompilerException.ErrorSeverity.Error.toString());
                 libraryNameErrorsMap.put(libraryName, Arrays.asList(error));
                 errors.add(error);
             }
         }
     }
 
-    private static void setCQLErrors(String parentLibraryName, List<CQLError> errors, Map<String, List<CQLError>> libraryToErrorsMap, CqlTranslatorException cte) {
+    private static void setCQLErrors(String parentLibraryName, List<CQLError> errors, Map<String, List<CQLError>> libraryToErrorsMap, CqlCompilerException cte) {
         CQLError cqlError = new CQLError();
 
         String libraryName = "";

--- a/src/main/java/mat/server/util/QDMUtil.java
+++ b/src/main/java/mat/server/util/QDMUtil.java
@@ -1,8 +1,8 @@
 package mat.server.util;
 
 import mat.client.shared.QDMContainer;
-import org.cqframework.cql.cql2elm.QdmModelInfoProvider;
-import org.hl7.elm.r1.VersionedIdentifier;
+import org.cqframework.cql.cql2elm.qdm.QdmModelInfoProvider;
+import org.hl7.cql.model.ModelIdentifier;
 import org.hl7.elm_modelinfo.r1.ChoiceTypeSpecifier;
 import org.hl7.elm_modelinfo.r1.ClassInfo;
 import org.hl7.elm_modelinfo.r1.ClassInfoElement;
@@ -29,9 +29,10 @@ public class QDMUtil {
     public static QDMContainer getQDMContainer() {
 
         QDMContainer qdmContainer = new QDMContainer();
-        VersionedIdentifier versionedIdentifier = new VersionedIdentifier();
-        versionedIdentifier.setId("QDM");
-        ModelInfo modelInfo = qdmModelInfoProvider.load(versionedIdentifier);
+        ModelIdentifier modelIdentifier = new ModelIdentifier();
+        modelIdentifier.setId("QDM");
+        modelIdentifier.setVersion("5.6");
+        ModelInfo modelInfo = qdmModelInfoProvider.load(modelIdentifier);
 
         Map<String, TypeInfo> nameToProfileInfoMap = new HashMap<>();
         Map<String, ClassInfo> nameToClassInfoMap = new HashMap<>();

--- a/src/main/java/mat/server/util/fhirxmlclean/FhirCleanerBase.java
+++ b/src/main/java/mat/server/util/fhirxmlclean/FhirCleanerBase.java
@@ -2,7 +2,7 @@ package mat.server.util.fhirxmlclean;
 
 import lombok.SneakyThrows;
 import mat.server.util.XmlProcessor;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 


### PR DESCRIPTION
## Description
Upgrade CQL-to-ELM Translator to 2.10.0

Adjust for refactored cqframework classes:

 - `TranslatedLibrary` renamed `CompiledLibrary`
 - `CqlTranslator.Options` moved to `CqlTranslatorOptions.Options`
 - `VersionedIdentifer` renamed/reworked to `ModelIdentifier`
 - `SystemModelInfoProvider` moved to `model` package
 - `CqlTranslatorException` renamed `CqlCompilerException`

Apache Commons Collections renamed package: `collections` -> `collections4`

Some CQL Translator dependencies were made runtime-only and needed to be set in MAT's pom:
- `model-jackson`: Resolves: No ModelInfoReaderProviders found on the classpath.
- `elm-jackson`: Resolves: No ElmLibraryWriterProviders found on the classpath.

There's `jaxb` variants of the above packages. Elected to go with `jackson` since MAT already uses it.

## JIRA Ticket
[MAT-5708](https://jira.cms.gov/browse/MAT-5708)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases.
- [x] Tests have been run locally and pass.

## Screenshots (if appropriate)
<!--- Put an `x` in the box when Screenshots are not relevant. Delete below line if adding screenshots. -->
- [x] None applicable
