### PR TITLE
[MAT-5710] Swap 'NQF' with 'CBE' Labelling

### DIFF
--- a/src/main/java/mat/client/measure/measuredetails/views/GeneralInformationView.java
+++ b/src/main/java/mat/client/measure/measuredetails/views/GeneralInformationView.java
@@ -75,7 +75,6 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
         this.isCompositeMeasure = isComposite;
         compositeChoices = MatContext.get().buildCompositeScoringChoiceList();
         buildDetailView();
-//        entityName = ModelTypeHelper.isFhir(MatContext.get().getCurrentMeasureModel()) ? "NQF" : "CBE";
     }
 
     @Override
@@ -122,7 +121,7 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
             panelGrid.setWidget(3, 1, buildExperimentalPanel());
         }
         panelGrid.setWidget(4, 0, buildeCQMVersionPanel());
-        panelGrid.setWidget(5, 0, buldeCQMIdentifierPanel());
+        panelGrid.setWidget(5, 0, buildECQMIdentifierPanel());
         panelGrid.setWidget(6, 0, buildNQFNumberPanel());
         panelGrid.setWidget(7, 0, buildMeasurementPeriodPanel());
         hackTheColspan(panelGrid);
@@ -274,7 +273,6 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
 
         FormLabel nQFIDInputLabel = new FormLabel();
         nQFIDInputLabel.setText("\n" + CBE_ABBR + " Number");
-//        nqfNumberRightVP.setVerticalAlignment(HasVerticalAlignment.ALIGN_BOTTOM);
         nqfNumberRightVP.add(nQFIDInputLabel);
         nqfNumberRightVP.add(new SpacerWidget());
         nqfNumberRightVP.add(nQFIDInput);
@@ -338,7 +336,7 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
         }
     }
 
-    private VerticalPanel buldeCQMIdentifierPanel() {
+    private VerticalPanel buildECQMIdentifierPanel() {
         VerticalPanel verticalPanel = new VerticalPanel();
         verticalPanel.getElement().addClassName("generalInformationPanel");
         HorizontalPanel horizontalPanel = new HorizontalPanel();

--- a/src/main/java/mat/client/measure/measuredetails/views/GeneralInformationView.java
+++ b/src/main/java/mat/client/measure/measuredetails/views/GeneralInformationView.java
@@ -6,7 +6,6 @@ import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.CheckBox;
-import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.TextArea;
 import com.google.gwt.user.client.ui.*;
 import mat.client.codelist.HasListBox;
@@ -66,7 +65,8 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
     protected CheckBox experimentalCheckbox = new CheckBox();
     private FormLabel measureNameLabel;
     private ErrorHandler errorHandler = new ErrorHandler();
-    private final String entityName = "CBE";
+    private final String CBE_ABBR = "CBE";
+    private final String CBE_FULL = "CMS Consensus Based Entity";
     private static final Logger logger = Logger.getLogger(GeneralInformationView.class.getSimpleName());
 
     public GeneralInformationView(boolean isComposite, GeneralInformationModel originalGeneralInformationModel) {
@@ -268,12 +268,13 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
     private VerticalPanel buildNQFNumberPanel() {
         VerticalPanel verticalPanel = new VerticalPanel();
         verticalPanel.getElement().addClassName("generalInformationPanel");
-        HorizontalPanel nqfNumberEndorsmentPanel = new HorizontalPanel();
+        HorizontalPanel nqfNumberEndorsementPanel = new HorizontalPanel();
         VerticalPanel nqfNumberLeftVP = new VerticalPanel();
         VerticalPanel nqfNumberRightVP = new VerticalPanel();
 
         FormLabel nQFIDInputLabel = new FormLabel();
-        nQFIDInputLabel.setText(entityName + " Number");
+        nQFIDInputLabel.setText("\n" + CBE_ABBR + " Number");
+//        nqfNumberRightVP.setVerticalAlignment(HasVerticalAlignment.ALIGN_BOTTOM);
         nqfNumberRightVP.add(nQFIDInputLabel);
         nqfNumberRightVP.add(new SpacerWidget());
         nqfNumberRightVP.add(nQFIDInput);
@@ -287,8 +288,8 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
             nQFIDInput.setTitle(generalInformationModel.getNqfId());
         } else {
             if (ModelTypeHelper.isFhir(MatContext.get().getCurrentMeasureModel())) {
-                nQFIDInput.setPlaceholder("Enter " + entityName + "Number");
-                nQFIDInput.setTitle("Enter " + entityName + "Number");
+                nQFIDInput.setPlaceholder("Enter " + CBE_ABBR + "Number");
+                nQFIDInput.setTitle("Enter " + CBE_ABBR + "Number");
             } else {
                 nQFIDInput.setPlaceholder("Enter CBE Number");
                 nQFIDInput.setTitle("Enter CBE Number");
@@ -296,15 +297,16 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
         }
 
         FormLabel endorsedByNQFLabel = new FormLabel();
-        endorsedByNQFLabel.setText("Endorsed By " + entityName);
+        endorsedByNQFLabel.setText("Endorsed By " + CBE_FULL);
         nqfNumberLeftVP.add(endorsedByNQFLabel);
         endorsedByListBox.setWidth("150px");
         endorsedByListBox.setId("endorsedByNQFListBox");
         nqfNumberLeftVP.add(endorsedByListBox);
         nqfNumberRightVP.getElement().setAttribute("style", "padding-left:10px;");
-        nqfNumberEndorsmentPanel.add(nqfNumberLeftVP);
-        nqfNumberEndorsmentPanel.add(nqfNumberRightVP);
-        verticalPanel.add(nqfNumberEndorsmentPanel);
+        nqfNumberEndorsementPanel.add(nqfNumberLeftVP);
+        nqfNumberEndorsementPanel.add(nqfNumberRightVP);
+        nqfNumberEndorsementPanel.setCellVerticalAlignment(nqfNumberRightVP, HasVerticalAlignment.ALIGN_BOTTOM);
+        verticalPanel.add(nqfNumberEndorsementPanel);
         resetEndorsedByListBox();
 
         boolean endorsedByNQF = generalInformationModel.getEndorseByNQF() != null ? generalInformationModel.getEndorseByNQF() : false;
@@ -318,7 +320,7 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
 
     public void setNQFTitle(boolean endorsedByNQF) {
         if (!endorsedByNQF) {
-            helpBlock.setText("You have chosen no; the " + entityName + " number field has been cleared. It now reads as Not Applicable and is disabled.");
+            helpBlock.setText("You have chosen no; the " + CBE_ABBR + " Number field has been cleared. It now reads as Not Applicable and is disabled.");
             nQFIDInput.setPlaceholder(MatConstants.NOT_APPLICABLE);
             nQFIDInput.setTitle(MatConstants.NOT_APPLICABLE);
             nQFIDInput.setText("");
@@ -326,14 +328,14 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
             nQFIDInput.setEnabled(false);
             nQFIDInput.setTabIndex(-1);
         } else {
-            helpBlock.setText("You have chosen yes, the " + entityName + " number field is now enabled and required.");
+            helpBlock.setText("You have chosen yes, the " + CBE_ABBR + " Number field is now enabled and required.");
             if (!StringUtility.isEmptyOrNull(nQFIDInput.getText())) {
                 String placeHolderText = nQFIDInput.getText();
                 nQFIDInput.setPlaceholder(placeHolderText);
                 nQFIDInput.setTitle(placeHolderText);
             } else {
-                nQFIDInput.setPlaceholder("Enter " + entityName + " Number");
-                nQFIDInput.setTitle("Enter " + entityName + " Number");
+                nQFIDInput.setPlaceholder("Enter " + CBE_ABBR + " Number");
+                nQFIDInput.setTitle("Enter " + CBE_ABBR + " Number");
             }
             nQFIDInput.setReadOnly(false);
             nQFIDInput.setEnabled(true);

--- a/src/main/java/mat/client/measure/measuredetails/views/GeneralInformationView.java
+++ b/src/main/java/mat/client/measure/measuredetails/views/GeneralInformationView.java
@@ -66,6 +66,7 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
     protected CheckBox experimentalCheckbox = new CheckBox();
     private FormLabel measureNameLabel;
     private ErrorHandler errorHandler = new ErrorHandler();
+    private final String entityName = "CBE";
     private static final Logger logger = Logger.getLogger(GeneralInformationView.class.getSimpleName());
 
     public GeneralInformationView(boolean isComposite, GeneralInformationModel originalGeneralInformationModel) {
@@ -74,6 +75,7 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
         this.isCompositeMeasure = isComposite;
         compositeChoices = MatContext.get().buildCompositeScoringChoiceList();
         buildDetailView();
+//        entityName = ModelTypeHelper.isFhir(MatContext.get().getCurrentMeasureModel()) ? "NQF" : "CBE";
     }
 
     @Override
@@ -271,7 +273,7 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
         VerticalPanel nqfNumberRightVP = new VerticalPanel();
 
         FormLabel nQFIDInputLabel = new FormLabel();
-        nQFIDInputLabel.setText("NQF Number");
+        nQFIDInputLabel.setText(entityName + " Number");
         nqfNumberRightVP.add(nQFIDInputLabel);
         nqfNumberRightVP.add(new SpacerWidget());
         nqfNumberRightVP.add(nQFIDInput);
@@ -284,12 +286,17 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
             nQFIDInput.setText(generalInformationModel.getNqfId());
             nQFIDInput.setTitle(generalInformationModel.getNqfId());
         } else {
-            nQFIDInput.setPlaceholder(MatConstants.ENTER_NQF_NUMBER);
-            nQFIDInput.setTitle(MatConstants.ENTER_NQF_NUMBER);
+            if (ModelTypeHelper.isFhir(MatContext.get().getCurrentMeasureModel())) {
+                nQFIDInput.setPlaceholder("Enter " + entityName + "Number");
+                nQFIDInput.setTitle("Enter " + entityName + "Number");
+            } else {
+                nQFIDInput.setPlaceholder("Enter CBE Number");
+                nQFIDInput.setTitle("Enter CBE Number");
+            }
         }
 
         FormLabel endorsedByNQFLabel = new FormLabel();
-        endorsedByNQFLabel.setText("Endorsed By NQF");
+        endorsedByNQFLabel.setText("Endorsed By " + entityName);
         nqfNumberLeftVP.add(endorsedByNQFLabel);
         endorsedByListBox.setWidth("150px");
         endorsedByListBox.setId("endorsedByNQFListBox");
@@ -311,7 +318,7 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
 
     public void setNQFTitle(boolean endorsedByNQF) {
         if (!endorsedByNQF) {
-            helpBlock.setText("You have chosen no; the NQF number field has been cleared. It now reads as Not Applicable and is disabled.");
+            helpBlock.setText("You have chosen no; the " + entityName + " number field has been cleared. It now reads as Not Applicable and is disabled.");
             nQFIDInput.setPlaceholder(MatConstants.NOT_APPLICABLE);
             nQFIDInput.setTitle(MatConstants.NOT_APPLICABLE);
             nQFIDInput.setText("");
@@ -319,14 +326,14 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
             nQFIDInput.setEnabled(false);
             nQFIDInput.setTabIndex(-1);
         } else {
-            helpBlock.setText("You have chosen yes, the NQF number field is now enabled and required.");
+            helpBlock.setText("You have chosen yes, the " + entityName + " number field is now enabled and required.");
             if (!StringUtility.isEmptyOrNull(nQFIDInput.getText())) {
                 String placeHolderText = nQFIDInput.getText();
                 nQFIDInput.setPlaceholder(placeHolderText);
                 nQFIDInput.setTitle(placeHolderText);
             } else {
-                nQFIDInput.setPlaceholder(MatConstants.ENTER_NQF_NUMBER);
-                nQFIDInput.setTitle(MatConstants.ENTER_NQF_NUMBER);
+                nQFIDInput.setPlaceholder("Enter " + entityName + " Number");
+                nQFIDInput.setTitle("Enter " + entityName + " Number");
             }
             nQFIDInput.setReadOnly(false);
             nQFIDInput.setEnabled(true);
@@ -921,7 +928,7 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
         endorsedByListBox.insertItem("No", "false", "No");
         endorsedByListBox.insertItem("Yes", "true", "Yes");
         endorsedByListBox.setSelectedIndex(0);
-        endorsedByListBox.setTitle("Endorsed By NQF List");
+        endorsedByListBox.setTitle("Endorsed By CBE List");
     }
 
     public ListBoxMVP getEndorsedByListBox() {

--- a/src/main/java/mat/client/measure/measuredetails/views/GeneralInformationView.java
+++ b/src/main/java/mat/client/measure/measuredetails/views/GeneralInformationView.java
@@ -287,13 +287,8 @@ public class GeneralInformationView implements MeasureDetailViewInterface {
             nQFIDInput.setText(generalInformationModel.getNqfId());
             nQFIDInput.setTitle(generalInformationModel.getNqfId());
         } else {
-            if (ModelTypeHelper.isFhir(MatContext.get().getCurrentMeasureModel())) {
-                nQFIDInput.setPlaceholder("Enter " + CBE_ABBR + "Number");
-                nQFIDInput.setTitle("Enter " + CBE_ABBR + "Number");
-            } else {
-                nQFIDInput.setPlaceholder("Enter CBE Number");
-                nQFIDInput.setTitle("Enter CBE Number");
-            }
+            nQFIDInput.setPlaceholder("Enter " + CBE_ABBR + "Number");
+            nQFIDInput.setTitle("Enter " + CBE_ABBR + "Number");
         }
 
         FormLabel endorsedByNQFLabel = new FormLabel();

--- a/src/main/java/mat/client/shared/MessageDelegate.java
+++ b/src/main/java/mat/client/shared/MessageDelegate.java
@@ -9,7 +9,7 @@ public class MessageDelegate {
     public static final String CQL_FUNCTION_ARGUMENT_NAME_ERROR = "Invalid argument name. Must start with an alpha-character or underscore followed by an alpha-numeric character(s) or underscore(s), and must not contain spaces.";
     public static final String CONTINUOUS_VARIABLE_IS_NOT_PATIENT_BASED_ERROR = "Continuous Variable measures must not be patient based.";
     public static final String s_ERR_RETRIEVE_SCORING_CHOICES = "Problem while retrieving measure scoring choices.";
-    public static final String CBE_NUMBER_REQUIRED_ERROR = "CBE Number is required when a measure is Endorsed by CBE.";
+    public static final String CBE_NUMBER_REQUIRED_ERROR = "CBE Number is required when a measure is Endorsed by a CMS Consensus Based Entity.";
     public static final String SECURITY_QUESTION_ANSWERS_MUST_CONTAIN_AT_LEAST_THREE_CHARACTERS = "Security question answers must contain at least three characters.";
     public static final String ALL_SECURITY_QUESTIONS_MUST_CONTAIN_A_VALID_SECURITY_ANSWER = "All security questions must contain a valid security answer";
     public static final String GENERIC_ERROR_MESSAGE = "The Measure Authoring Tool was unable to process the request. Please try again. If the problem persists please contact the Help Desk.";

--- a/src/main/java/mat/client/shared/MessageDelegate.java
+++ b/src/main/java/mat/client/shared/MessageDelegate.java
@@ -9,7 +9,7 @@ public class MessageDelegate {
     public static final String CQL_FUNCTION_ARGUMENT_NAME_ERROR = "Invalid argument name. Must start with an alpha-character or underscore followed by an alpha-numeric character(s) or underscore(s), and must not contain spaces.";
     public static final String CONTINUOUS_VARIABLE_IS_NOT_PATIENT_BASED_ERROR = "Continuous Variable measures must not be patient based.";
     public static final String s_ERR_RETRIEVE_SCORING_CHOICES = "Problem while retrieving measure scoring choices.";
-    public static final String NQF_NUMBER_REQUIRED_ERROR = "NQF Number is required when a measure is Endorsed by NQF.";
+    public static final String CBE_NUMBER_REQUIRED_ERROR = "CBE Number is required when a measure is Endorsed by CBE.";
     public static final String SECURITY_QUESTION_ANSWERS_MUST_CONTAIN_AT_LEAST_THREE_CHARACTERS = "Security question answers must contain at least three characters.";
     public static final String ALL_SECURITY_QUESTIONS_MUST_CONTAIN_A_VALID_SECURITY_ANSWER = "All security questions must contain a valid security answer";
     public static final String GENERIC_ERROR_MESSAGE = "The Measure Authoring Tool was unable to process the request. Please try again. If the problem persists please contact the Help Desk.";

--- a/src/main/java/mat/server/service/impl/xsl/qdm_v5_6_measure_details.xsl
+++ b/src/main/java/mat/server/service/impl/xsl/qdm_v5_6_measure_details.xsl
@@ -285,7 +285,7 @@
         <subjectOf>
             <measureAttribute>
                 <code nullFlavor="OTH">
-                    <originalText value="NQF Number"/>
+                    <originalText value="CBE Number"/>
                 </code>
                 <xsl:variable name="NQFText">
                     <xsl:call-template name="trim">

--- a/src/main/java/mat/shared/MatConstants.java
+++ b/src/main/java/mat/shared/MatConstants.java
@@ -94,5 +94,4 @@ public interface MatConstants {
 	String DURING = "During";
 	String OVERLAPS =  "Overlaps";
 	String NOT_APPLICABLE = "Not Applicable";
-	String ENTER_NQF_NUMBER = "Enter NQF Number";
 }

--- a/src/main/java/mat/shared/validator/measure/ManageMeasureModelValidator.java
+++ b/src/main/java/mat/shared/validator/measure/ManageMeasureModelValidator.java
@@ -31,7 +31,7 @@ public class ManageMeasureModelValidator {
 		List<String> message = new ArrayList<>();
 		if (Optional.ofNullable(model.getEndorseByNQF()).orElse(false)) {
 			if (StringUtility.isEmptyOrNull(model.getNqfId())) {
-				message.add(MessageDelegate.NQF_NUMBER_REQUIRED_ERROR);
+				message.add(MessageDelegate.CBE_NUMBER_REQUIRED_ERROR);
 			}
 		}
 		return message;

--- a/src/main/resources/templates/humanreadable/measure_information_table.ftl
+++ b/src/main/resources/templates/humanreadable/measure_information_table.ftl
@@ -13,7 +13,7 @@
             <td style="width:30%">${model.measureInformation.ecqmVersionNumber}</td>
         </tr>
         <tr>
-            <th scope="row" class="row-header"><span class="td_label">NQF Number</span></th>
+            <th scope="row" class="row-header"><span class="td_label">CBE Number</span></th>
             <#-- Default to "Not Applicable" if there is no value -->
             <td style="width:30%">${model.measureInformation.nqfNumber!"Not Applicable"}</td>
 

--- a/src/main/resources/templates/humanreadable/measure_information_table.ftl
+++ b/src/main/resources/templates/humanreadable/measure_information_table.ftl
@@ -53,7 +53,7 @@
             </tr>
         </#if>
         <tr>
-            <th scope="row" class="row-header"><span class="td_label">Endorsed By</span></th>
+            <th scope="row" class="row-header"><span class="td_label">Endorsed By CMS Consensus Based Entity</span></th>
             <#-- Default to "None" if no value -->
             <td style="width:80%" colspan="3">${model.measureInformation.endorsedBy!"None"}</td>
         </tr>


### PR DESCRIPTION
## Description
The NQF will no longer certifies measures. To avoid renaming each time the certifying contractor changes, CMS has selected more generic terminology. Namely, "Consensus Based Entity" or shortened to "CBE".

This PR replaces user facing instances of `NQF` with `CBE` and `Endorsed by` with `Endorsed by CMS Consensus Based Entity` in:
- Measure Details Tab
- Human Readable's Measure Information table
- HQMF

Code models are not being updated in this PR. It'll be a future effort to replace references to NQF across the codebase.

## JIRA Ticket
[MAT-5710](https://jira.cms.gov/browse/MAT-5710)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [x] Tests have been run locally and pass.

## Screenshots (if appropriate)
#### Measure Details
![Screen Shot 2023-06-12 at 2 01 14 PM](https://github.com/MeasureAuthoringTool/MeasureAuthoringTool/assets/56264529/3022c8a7-f053-4296-aa37-67990b45e265)

#### Human Readable
![Screen Shot 2023-06-12 at 2 01 29 PM](https://github.com/MeasureAuthoringTool/MeasureAuthoringTool/assets/56264529/54a9f9dc-0f2d-4891-bb9a-b68e808cc80f)

#### HQMF
![Screen Shot 2023-06-12 at 2 02 49 PM](https://github.com/MeasureAuthoringTool/MeasureAuthoringTool/assets/56264529/83e6c4de-1f0e-43d7-98b8-159c04d18d3a)

