### PR TITLE
[MAT-6676] Feature flag control of CMS ID Generation UI

### DIFF
--- a/src/main/java/liquibase/CmsIdGenerationFlag.xml
+++ b/src/main/java/liquibase/CmsIdGenerationFlag.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="mat_dev_user" id="1" context="prod">
+        <preConditions onFail="MARK_RAN">
+            <tableExists tableName="FEATURE_FLAGS"/>
+        </preConditions>
+        <insert tableName="FEATURE_FLAGS">
+            <column name="FLAG_NAME" value="CMS_ID_GENERATION"/>
+            <column name="FLAG_ON" value="0"/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/java/liquibase/changelog.xml
+++ b/src/main/java/liquibase/changelog.xml
@@ -13,4 +13,5 @@
     <include file="classpath:/liquibase/AddFinalizedDateForFhirLibraries.xml"/>
     <include file="classpath:/liquibase/add_measure_transfer_column_to_measure.xml"/>
     <include file="classpath:/liquibase/Payer_valueset_MeasureXmlUpdate.xml"/>
+    <include file="classpath:/liquibase/CmsIdGenerationFlag.xml"/>
 </databaseChangeLog>

--- a/src/main/java/mat/client/measure/ManageMeasurePresenter.java
+++ b/src/main/java/mat/client/measure/ManageMeasurePresenter.java
@@ -58,6 +58,7 @@ import mat.client.shared.SynchronizationDelegate;
 import mat.client.shared.WarningConfirmationMessageAlert;
 import mat.client.shared.search.SearchResultUpdate;
 import mat.client.util.ClientConstants;
+import mat.client.util.FeatureFlagConstant;
 import mat.client.util.MatTextBox;
 import mat.dto.CompositeMeasureScoreDTO;
 import mat.dto.SearchHistoryDTO;
@@ -1010,7 +1011,11 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
         warningConfirmationMessageAlert = detailDisplay.getWarningConfirmationMessageAlert();
         currentDetails = new ManageMeasureDetailModel();
         detailDisplay.showCautionMsg(false);
-        showOptionCheckboxes(detailDisplay);
+        if (MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.CMS_ID_GENERATION)) {
+            showCmsIdOptionCheckboxes(detailDisplay);
+        } else {
+            hideCmsIdOptionCheckboxes(detailDisplay);
+        }
         displayCommonDetailForAdd(detailDisplay);
         panel.setHeading("My Measures > Create New Measure", MEASURE_LIBRARY);
         setDetailsToView();
@@ -1027,7 +1032,7 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
         Mat.focusSkipLists(MEASURE_LIBRARY);
         detailDisplay.showMeasureName(true);
         detailDisplay.showCautionMsg(true);
-        hideOptionCheckboxes(detailDisplay);
+        hideCmsIdOptionCheckboxes(detailDisplay);
         setDetailsToView();
 
         detailDisplay.getMeasureNameTextBox().setValue("");
@@ -1045,18 +1050,18 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
         Mat.focusSkipLists(MEASURE_LIBRARY);
         detailDisplay.showCautionMsg(true);
         detailDisplay.showMeasureName(true);
-        hideOptionCheckboxes(detailDisplay);
+        hideCmsIdOptionCheckboxes(detailDisplay);
         setDetailsToView();
         updateSaveButtonClickHandler(event -> draftMeasure());
         panel.setContent(detailDisplay.asWidget());
     }
 
-    private void hideOptionCheckboxes(DetailDisplay detailDisplay) {
+    private void hideCmsIdOptionCheckboxes(DetailDisplay detailDisplay) {
         MatContext.get().setVisible(detailDisplay.getGenerateCmsIdCheckbox(), false);
         MatContext.get().setVisible(detailDisplay.getMatchLibraryNameToCmsIdCheckbox(), false);
     }
 
-    private void showOptionCheckboxes(DetailDisplay detailDisplay) {
+    private void showCmsIdOptionCheckboxes(DetailDisplay detailDisplay) {
         MatContext.get().setVisible(detailDisplay.getGenerateCmsIdCheckbox(), true);
         MatContext.get().setVisible(detailDisplay.getMatchLibraryNameToCmsIdCheckbox(), true);
     }
@@ -1065,7 +1070,11 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
         clearErrorMessageAlerts();
         warningConfirmationMessageAlert = compositeDetailDisplay.getWarningConfirmationMessageAlert();
         displayCommonDetailForAdd(compositeDetailDisplay);
-        showOptionCheckboxes(compositeDetailDisplay);
+        if (MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.CMS_ID_GENERATION)) {
+            showCmsIdOptionCheckboxes(compositeDetailDisplay);
+        } else {
+            hideCmsIdOptionCheckboxes(compositeDetailDisplay);
+        }
         panel.setHeading("My Measures > Create New Composite Measure", COMPOSITE_MEASURE);
         setCompositeDetailsToView();
         Mat.focusSkipLists(COMPOSITE_MEASURE);
@@ -1081,7 +1090,7 @@ public class ManageMeasurePresenter implements MatPresenter, TabObserver {
         compositeDetailDisplay.setMeasureModelType(currentCompositeMeasureDetails.getMeasureModel());
         compositeDetailDisplay.showCautionMsg(true);
         compositeDetailDisplay.showMeasureName(true);
-        hideOptionCheckboxes(compositeDetailDisplay);
+        hideCmsIdOptionCheckboxes(compositeDetailDisplay);
         setCompositeDetailsToView();
         Mat.focusSkipLists(COMPOSITE_MEASURE);
         updateCompositeSaveButtonClickHandler(event -> draftCompositeMeasure());

--- a/src/main/java/mat/client/measure/measuredetails/views/MeasureDetailsViewFactory.java
+++ b/src/main/java/mat/client/measure/measuredetails/views/MeasureDetailsViewFactory.java
@@ -35,6 +35,7 @@ import mat.client.shared.MeasureDetailsConstants;
 import mat.client.shared.MeasureDetailsConstants.MeasureDetailsItems;
 import mat.client.shared.MeasureDetailsConstants.PopulationItems;
 import mat.client.shared.MessagePanel;
+import mat.client.util.FeatureFlagConstant;
 import mat.shared.measure.measuredetails.models.GeneralInformationModel;
 import mat.shared.measure.measuredetails.models.MeasureDetailsModel;
 import mat.shared.measure.measuredetails.models.MeasureDetailsTextAbstractModel;
@@ -130,6 +131,8 @@ public class MeasureDetailsViewFactory {
 
 	private GeneralInformationView buildGeneralMeasureInformationView(boolean isComposite, GeneralInformationModel generalInformationModel) {
 		final GeneralInformationView generalInformationView = new GeneralInformationView(isComposite, generalInformationModel);
+    MatContext.get().setVisible(generalInformationView.getGenerateEMeasureIDButton(),
+				MatContext.get().getFeatureFlagStatus(FeatureFlagConstant.CMS_ID_GENERATION));
 		final GeneralInformationObserver observer = new GeneralInformationObserver(generalInformationView);
 		generalInformationView.setObserver(observer);
 		return generalInformationView;

--- a/src/main/java/mat/client/util/FeatureFlagConstant.java
+++ b/src/main/java/mat/client/util/FeatureFlagConstant.java
@@ -7,4 +7,5 @@ public interface FeatureFlagConstant {
     String MADIE = "MADIE";
     String MADIE_QDM = "MADIE_QDM";
     String MADIE_QDM_RE_TRANSFER = "MADIE_QDM_RE_TRANSFER";
+    String CMS_ID_GENERATION = "CMS_ID_GENERATION";
 }

--- a/src/main/java/mat/server/FeatureFlagRemoteServiceImpl.java
+++ b/src/main/java/mat/server/FeatureFlagRemoteServiceImpl.java
@@ -18,5 +18,4 @@ public class FeatureFlagRemoteServiceImpl extends SpringRemoteServiceServlet imp
     public Map<String, Boolean> findFeatureFlags() {
         return flagService.findFeatureFlags();
     }
-
 }


### PR DESCRIPTION
<!--- In the *Title* field above, please provide the JIRA ticket number and a general summary of your changes -->
## Description
- MAT-6676: Add feature flag to hide/display CMS ID generation UI elements.
- MAT-6676: Show/hide CMS ID/eCQM ID generation checkboxes from new measure, new composite measure UI based on CMS_ID_GENERATION flag. If the flag cannot be read, defaults to false (hidden).
- MAT-6676: Show/hide CMS ID/eCQM ID generation button from Measure Details view based on CMS_ID_GENERATION flag. If the flag cannot be read, defaults to false (hidden).

## JIRA Ticket
[MAT-6676](https://jira.cms.gov/browse/MAT-6676)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases.
- [ ] Tests have been run locally and pass.

## Screenshots (if appropriate)
### New Measure
![Screenshot 2024-02-08 at 1 14 48 PM](https://github.com/MeasureAuthoringTool/MeasureAuthoringTool/assets/56264529/c216c019-0bdf-4705-b95a-da9b3cd3b8cd)
### New Composite Measure
![Screenshot 2024-02-08 at 1 15 02 PM](https://github.com/MeasureAuthoringTool/MeasureAuthoringTool/assets/56264529/283babfd-fcec-4a98-99d5-cad8ca4124ae)
### Measure Details
![Screenshot 2024-02-08 at 1 15 13 PM](https://github.com/MeasureAuthoringTool/MeasureAuthoringTool/assets/56264529/17de867f-db64-43cc-b9dd-23277f991de6)